### PR TITLE
feat: add PubMed acquisition pipeline (/epistract-acquire)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ export AWS_REGION_NAME="us-east-1"
 
 This is separate from Claude Code's own API access, which is handled by your Claude Code subscription.
 
+**PubMed API key (optional)** — if you plan to use `/epistract-acquire` to search and download articles from PubMed, an NCBI API key increases rate limits from 3 to 10 requests/second. The key is free.
+
+To obtain one:
+1. Create a free NCBI account at https://www.ncbi.nlm.nih.gov/account/
+2. Sign in, go to **Settings** > **API Key Management** > **Create an API Key**
+3. Set it in your environment:
+
+```bash
+export NCBI_API_KEY="your-key-here"
+```
+
+> **Note:** The PubMed connector works without this key — it just runs at lower rate limits. For small corpora (<20 articles) you likely won't notice the difference. For larger acquisitions, the key prevents rate-limit pauses.
+
 ### 2. Ingest Documents
 
 ```
@@ -118,6 +131,7 @@ The interactive viewer shows your knowledge graph with labeled community regions
 | Command | Description |
 |---|---|
 | `/epistract-setup` | Install dependencies (sift-kg, optional RDKit/Biopython) |
+| `/epistract-acquire <query>` | Search PubMed and download articles into a local corpus |
 | `/epistract-ingest <path>` | Full pipeline: ingest → extract → validate → build → view |
 | `/epistract-build` | Build graph from existing extractions |
 | `/epistract-validate` | Validate molecular identifiers in extractions |
@@ -292,9 +306,11 @@ See [tests/FINDINGS.md](tests/FINDINGS.md) for the complete engineering findings
 flowchart TB
     subgraph CC["Claude Code Runtime"]
         subgraph EP["Epistract Plugin"]
+            ACQ["Acquire<br/>/acquire"]
             CMD["Commands<br/>/ingest /build /view<br/>/query /export /validate"]
             SKL["Drug Discovery<br/>Extraction Skill"]
-            AGT["Agents<br/>extractor · validator"]
+            AGT["Agents<br/>extractor · validator<br/>acquirer"]
+            ACQ --> CMD
             CMD --> SKL
             SKL --> AGT
         end
@@ -309,7 +325,9 @@ flowchart TB
         end
         EP --> SK
     end
+    PUB["PubMed<br/>NCBI E-utilities"] --> ACQ
     USR["Scientist / Researcher"] --> CMD
+    USR --> ACQ
     VIZ --> BRW["Browser"]
     EXP --> EXT["Gephi · Cytoscape<br/>DuckDB · pandas"]
 ```
@@ -318,6 +336,7 @@ flowchart TB
 
 ```mermaid
 flowchart LR
+    PUB["PubMed Search<br/>/acquire<br/>(optional)"] -.-> DOCS
     DOCS["Documents<br/>PDF · DOCX · HTML<br/>TXT · Patents"] --> ING["Text Extraction<br/>+ Chunking"]
     ING --> EXT["Claude Extraction<br/>Entities + Relations"]
     EXT --> VAL["Molecular Validation<br/>RDKit · Biopython"]

--- a/agents/acquirer.md
+++ b/agents/acquirer.md
@@ -1,0 +1,52 @@
+---
+description: >
+  Fetch a batch of PubMed articles for the epistract corpus. Dispatched by
+  /epistract-acquire when processing many articles in parallel. Each agent
+  handles a batch of PMIDs independently.
+---
+
+# PubMed Article Acquisition Agent
+
+You are fetching a batch of PubMed articles for the epistract corpus.
+
+## Your Task
+
+You will be given a list of PMIDs to fetch. For each PMID:
+
+1. Use the PubMed connector to retrieve the article metadata (title, authors, journal, year, abstract, MeSH terms, DOI, PMC ID)
+2. If a PMC ID is available and full-text retrieval was requested, fetch the full article text
+3. Collect all articles into a single JSON array
+
+## Output
+
+Write the collected articles to disk using the write script:
+
+```bash
+echo '<articles_json>' | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/write_pubmed_doc.py <output_dir>
+```
+
+The JSON format:
+```json
+{
+  "articles": [
+    {
+      "pmid": "12345678",
+      "title": "...",
+      "abstract": "...",
+      "authors": ["Last First"],
+      "journal": "...",
+      "year": "2024",
+      "mesh_terms": ["term1"],
+      "doi": "10.1234/...",
+      "pmc_id": "PMC1234567",
+      "full_text": "..."
+    }
+  ]
+}
+```
+
+## Rules
+
+- Respect NCBI rate limits — if rate-limited, wait briefly and retry
+- Skip articles with no abstract and no full text
+- Report how many articles were written vs skipped

--- a/commands/acquire.md
+++ b/commands/acquire.md
@@ -1,0 +1,97 @@
+---
+name: epistract-acquire
+description: Search PubMed and download articles into a local corpus for epistract ingestion
+---
+
+# Epistract PubMed Acquisition
+
+You are building a document corpus from PubMed for the epistract knowledge graph pipeline.
+
+## Prerequisites
+
+The **PubMed connector** must be available. If it is not connected, tell the user:
+
+> PubMed connector not found. Connect it in Claude settings (Settings > Connectors > PubMed)
+> or in Claude Code: `/plugin marketplace add anthropics/life-sciences && /plugin install pubmed@life-sciences`
+
+## Arguments
+- `query` (required): PubMed search query (supports standard PubMed syntax)
+- `--max` (optional): Maximum articles to fetch (default: 20)
+- `--output` (optional): Output directory (default: ./epistract-corpus)
+- `--full-text` (optional): Attempt to fetch full text from PMC when available (default: true)
+
+## Pipeline Steps
+
+### Step 1: Search PubMed
+
+Use the PubMed connector to search for articles matching the query. Respect NCBI rate limits — if you receive a rate limit message, wait briefly and retry.
+
+Refine the query if needed for better results. For example, add date filters, MeSH terms, or journal restrictions based on the user's intent.
+
+### Step 2: Fetch Article Metadata
+
+For each result, collect:
+- PMID
+- Title
+- Authors (list)
+- Journal name
+- Publication year
+- Abstract text
+- MeSH terms (if available)
+- DOI (if available)
+- PMC ID (if available)
+
+### Step 3: Fetch Full Text (when available)
+
+If `--full-text` is enabled and a PMC ID is present, use the PubMed connector to retrieve the full article text from PubMed Central. Not all articles have full text — this is expected. Abstracts are sufficient for extraction.
+
+### Step 4: Deduplicate
+
+Check the output directory for existing `pmid_*.txt` files. Skip articles already in the corpus.
+
+### Step 5: Write Corpus Files
+
+Build a JSON array of articles and write them to disk:
+
+```bash
+echo '<articles_json>' | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/write_pubmed_doc.py <output_dir>
+```
+
+The JSON format expected by the script:
+```json
+{
+  "articles": [
+    {
+      "pmid": "12345678",
+      "title": "...",
+      "abstract": "...",
+      "authors": ["Last First"],
+      "journal": "...",
+      "year": "2024",
+      "mesh_terms": ["term1"],
+      "doi": "10.1234/...",
+      "pmc_id": "PMC1234567",
+      "full_text": "..."
+    }
+  ]
+}
+```
+
+**For 10+ articles:** Use the Agent tool to dispatch parallel acquirer agents (batches of 5) for speed.
+
+### Step 6: Report Summary
+
+Tell the user:
+- Total articles found vs fetched
+- Abstracts vs full-text breakdown
+- Duplicates skipped
+- MeSH term coverage (top terms across the corpus)
+- Output directory location
+- Suggest next step: `/epistract-ingest <output_dir>` to build the knowledge graph
+
+### Step 7: Offer Corpus Expansion
+
+If the result set is small (<10 articles), suggest:
+- Related search terms the user might try
+- PubMed syntax tips (date ranges, MeSH qualifiers, author filters)
+- Cross-referencing with related articles from the connector

--- a/scripts/write_pubmed_doc.py
+++ b/scripts/write_pubmed_doc.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Write PubMed article metadata to the epistract corpus text format.
+
+Produces plain-text files matching the format used by existing test corpora
+(Title, Authors, Journal, PMID, MeSH, ABSTRACT), so that /epistract-ingest
+can process them without modification.
+
+Usage:
+    echo '<json>' | python write_pubmed_doc.py <output_dir>
+    python write_pubmed_doc.py <output_dir> --json '<json>'
+
+Input JSON schema:
+    {
+        "articles": [
+            {
+                "pmid": "12345678",
+                "title": "...",
+                "abstract": "...",
+                "authors": ["Last First", ...],
+                "journal": "...",
+                "year": "2024",
+                "mesh_terms": ["term1", "term2"],
+                "pmc_id": "PMC1234567",       // optional
+                "doi": "10.1234/...",          // optional
+                "full_text": "..."             // optional, from PMC
+            }
+        ]
+    }
+
+Output:
+    <output_dir>/docs/pmid_<PMID>.txt  (one per article)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def write_article(article: dict, docs_dir: Path) -> str | None:
+    """Write a single article to the corpus directory.
+
+    Returns the filename written, or None if skipped.
+    """
+    pmid = article.get("pmid", "").strip()
+    if not pmid:
+        return None
+
+    title = article.get("title", "").strip()
+    abstract = article.get("abstract", "").strip()
+    full_text = article.get("full_text", "").strip()
+
+    # Skip articles with no usable text
+    if not abstract and not full_text:
+        return None
+
+    authors = article.get("authors", [])
+    if isinstance(authors, str):
+        authors = [a.strip() for a in authors.split(",")]
+    author_line = ", ".join(authors[:10])
+
+    journal = article.get("journal", "").strip()
+    year = article.get("year", "").strip()
+    mesh_terms = article.get("mesh_terms", [])
+    doi = article.get("doi", "").strip()
+    pmc_id = article.get("pmc_id", "").strip()
+
+    # Build metadata header
+    lines = [
+        f"Title: {title}",
+        f"Authors: {author_line}",
+        f"Journal: {journal} ({year})" if year else f"Journal: {journal}",
+        f"PMID: {pmid}",
+    ]
+    if doi:
+        lines.append(f"DOI: {doi}")
+    if pmc_id:
+        lines.append(f"PMC: {pmc_id}")
+    lines.append("Source: PubMed via Claude PubMed Connector")
+    if mesh_terms:
+        lines.append(f"MeSH Terms: {', '.join(mesh_terms)}")
+
+    # Body: prefer full text when available, fall back to abstract
+    if full_text:
+        lines.append("")
+        lines.append("FULL TEXT:")
+        lines.append(full_text)
+    elif abstract:
+        lines.append("")
+        lines.append("ABSTRACT:")
+        lines.append(abstract)
+
+    fname = f"pmid_{pmid}.txt"
+    out_path = docs_dir / fname
+    out_path.write_text("\n".join(lines), encoding="utf-8")
+    return fname
+
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    if not args:
+        print(
+            f"Usage: {sys.argv[0]} <output_dir> [--json '<json>']",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    output_dir = Path(args[0])
+    docs_dir = output_dir / "docs"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Read input JSON
+    if "--json" in args:
+        data = json.loads(args[args.index("--json") + 1])
+    else:
+        data = json.load(sys.stdin)
+
+    articles = data.get("articles", [])
+    if not articles:
+        print("No articles in input", file=sys.stderr)
+        sys.exit(1)
+
+    # Check for existing PMIDs to avoid duplicates
+    existing_pmids: set[str] = set()
+    for f in docs_dir.glob("pmid_*.txt"):
+        existing_pmids.add(f.stem.removeprefix("pmid_"))
+
+    written = []
+    skipped_dup = 0
+    skipped_empty = 0
+
+    for article in articles:
+        pmid = article.get("pmid", "").strip()
+        if pmid in existing_pmids:
+            skipped_dup += 1
+            continue
+
+        fname = write_article(article, docs_dir)
+        if fname:
+            written.append(fname)
+            existing_pmids.add(pmid)
+        else:
+            skipped_empty += 1
+
+    print(json.dumps({
+        "docs_dir": str(docs_dir),
+        "written": len(written),
+        "skipped_duplicate": skipped_dup,
+        "skipped_empty": skipped_empty,
+        "files": written,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Title: feat: add PubMed acquisition pipeline (/epistract-acquire)

  Body:
  ## Summary
  - Add `/epistract-acquire` command to search PubMed and download articles into a local corpus
  - Add `write_pubmed_doc.py` script to convert PubMed JSON metadata to epistract corpus format
  - Add `acquirer` agent definition for parallel batch fetching of articles
  - Supports full-text retrieval from PMC, deduplication, and MeSH term extraction

  ## Files Changed
  - `scripts/write_pubmed_doc.py` — corpus file writer with deduplication
  - `commands/acquire.md` — skill definition for `/epistract-acquire`
  - `agents/acquirer.md` — parallel batch acquisition agent
  - `README.md` — updated with acquisition pipeline documentation

  ## Test plan
  - [x] Tested with query "COVID-19 Vaccination and potential increase in cancer"
  - [x] Successfully acquired 24 articles (12 full-text, 12 abstract-only)
  - [x] Successfully ingested corpus through full pipeline (188 entities, 447 relations, 6 communities)
  - [x] Deduplication logic verified (no duplicates on re-run)