### PR TITLE
docs+fix: V2 architecture diagrams + corporate-env fixes (rdkit, SOCKS proxy)

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-04-02)
 Phase: 11 (end-to-end-scenario-validation) — EXECUTING
 Plan: 2 of 4
 Status: Ready to execute
-Last activity: 2026-04-04
+Last activity: 2026-04-16 - Completed quick task 260416-fkc: rdkit-pypi -> rdkit + SOCKS proxy bypass
 
 Progress: [████████░░] 85%
 
@@ -126,6 +126,12 @@ Recent decisions affecting current work:
 - Repo reorganization (Phase 6) is the critical path -- everything else depends on it
 - Domain wizard (Phase 7) needs the new `domains/` structure to exist before generating into it
 - Backward compatibility with biomedical scenarios must be preserved through reorganization
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260416-fkc | Fix rdkit-pypi -> rdkit (Py3.13+) and bypass SOCKS proxy in workbench api_chat.py | 2026-04-16 | 2fef783 | [260416-fkc-fix-rdkit-pypi-to-rdkit-python-3-13-and-](./quick/260416-fkc-fix-rdkit-pypi-to-rdkit-python-3-13-and-/) |
 
 ## Session Continuity
 

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -20,7 +20,7 @@
 - New contributors have no documented installation instructions
 
 **Fix approach:**
-1. Create `pyproject.toml` with optional dependency groups: `[project.optional-dependencies]` for `dev = ["rdkit-pypi>=2023.9", "biopython>=1.83"]`
+1. Create `pyproject.toml` with optional dependency groups: `[project.optional-dependencies]` for `dev = ["rdkit>=2023.9", "biopython>=1.83"]`
 2. Document installation: `uv pip install -e ".[dev]"` or `uv sync`
 3. Update CI/CD to verify dependencies are available during test runs
 4. Consider switching from graceful degradation to explicit validation: fail fast if validator is called without dependencies installed
@@ -484,7 +484,7 @@ dedup_report = build_dedup_report(dict(inchikey_map), output_dir)  # O(n) scan
 **Risk:** Scenario reproducibility: running the same extraction with RDKit 2023.9 vs. 2024.3 could produce different canonical SMILES, breaking dedup.
 
 **Mitigation approach:**
-1. Pin RDKit version in dependency manifest (once created): `rdkit-pypi==2023.9.1`
+1. Pin RDKit version in dependency manifest (once created): `rdkit==2023.9.1`
 2. Document version requirement in DEVELOPER.md: "Validated with RDKit 2023.9.1; other versions may produce different canonicalization"
 3. Add CI test: verify RDKit version matches pinned version before validation runs
 4. Create migration guide: if RDKit is upgraded, re-run validation pipeline and compare InChIKey output

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -118,7 +118,7 @@ sys.path.insert(0, str(VALIDATION_SCRIPTS))
   if not RDKIT_AVAILABLE:
       return {
           "valid": None,
-          "error": "RDKit not installed. Run: uv pip install rdkit-pypi",
+          "error": "RDKit not installed. Run: uv pip install rdkit",
       }
   ```
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -75,7 +75,7 @@
 **Optional: Molecular Validation**
 
 Install with `make setup-all` or `bash scripts/setup.sh --all`:
-- **RDKit** (rdkit-pypi) ~50MB - SMILES validation, canonicalization, molecular properties (Lipinski analysis)
+- **RDKit** (rdkit) ~50MB - SMILES validation, canonicalization, molecular properties (Lipinski analysis)
   - Provides: canonical SMILES, InChI, InChIKey, molecular formula, MW, LogP, HBD, HBA, TPSA
 - **Biopython** ~20MB - DNA/RNA/protein sequence validation, GC content, isoelectric point, molecular weight
   - Provides: sequence validation, type detection, reverse complement, translation, physiochemical properties

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -293,7 +293,7 @@ python -m pytest tests/test_unit.py::test_ut003_scan_nct -v
 python -m pytest tests/test_unit.py::test_ut011_detect_type -v
 
 # Run with optional dependencies
-uv pip install rdkit-pypi biopython sift-kg
+uv pip install rdkit biopython sift-kg
 make test
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Two pre-built domains demonstrate the framework:
 - **Typer** ≥0.9 - CLI framework for sift-kg command-line tools
 - **PyYAML** ≥6.0 - YAML parsing for domain schemas
 - **requests** - HTTP library used in test corpus assembly (PubMed E-utilities, SerpAPI calls)
-- **RDKit** (rdkit-pypi) ~50MB - SMILES validation, canonicalization, molecular properties (Lipinski analysis)
+- **RDKit** (rdkit) ~50MB - SMILES validation, canonicalization, molecular properties (Lipinski analysis)
 - **Biopython** ~20MB - DNA/RNA/protein sequence validation, GC content, isoelectric point, molecular weight
 - **sentence-transformers** ~2GB (PyTorch) - Semantic clustering for entity resolution (`sift-kg[embeddings]`)
 - **google-cloud-vision** ~20MB - Google Cloud Vision OCR (`sift-kg[ocr]`)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -98,7 +98,7 @@ This document is for developers extending, debugging, or integrating with Epistr
 
 | Dependency | Size | Purpose | Project |
 |---|---|---|---|
-| **RDKit** (rdkit-pypi) | ~50MB | SMILES validation, canonicalization, molecular properties, Lipinski analysis | [rdkit.org](https://www.rdkit.org/) |
+| **RDKit** (rdkit) | ~50MB | SMILES validation, canonicalization, molecular properties, Lipinski analysis | [rdkit.org](https://www.rdkit.org/) |
 | **Biopython** | ~20MB | Sequence validation (DNA/RNA/protein), GC content, isoelectric point, BLAST | [biopython.org](https://biopython.org/) |
 
 ### Optional: sift-kg Extras
@@ -397,7 +397,7 @@ The skill file contains the full domain schema and extraction prompt template. W
 | Script | Location | Dependencies | Purpose |
 |---|---|---|---|
 | `scan_patterns.py` | `skills/drug-discovery-extraction/validation-scripts/` | None (stdlib re) | Regex pattern scanning for SMILES, sequences, identifiers |
-| `validate_smiles.py` | Same | rdkit-pypi (optional) | SMILES validation, canonicalization, property computation |
+| `validate_smiles.py` | Same | rdkit (optional) | SMILES validation, canonicalization, property computation |
 | `validate_sequences.py` | Same | biopython (optional) | DNA/RNA/protein sequence validation and analysis |
 | `validate_molecules.py` | `scripts/` | Both optional | Orchestrator: scan → validate → enrich extraction JSONs |
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This shells out to `scripts/setup.sh`, which:
 2. Creates `.venv/` via `uv venv` if it doesn't already exist
 3. Checks Python 3.11–3.13 in that venv
 4. Installs `sift-kg` via `uv pip install` (targets the project `.venv` automatically)
-5. Optionally installs `rdkit-pypi` + `biopython` with `--all`
+5. Optionally installs `rdkit` + `biopython` with `--all`
 
 The script is idempotent — safe to re-run after upgrades. It does **not** fall back to plain `pip` on failure: if `uv pip install` can't reach PyPI (corporate SSL proxies are the usual culprit), it prints a clear error with remediation steps instead of silently installing into the wrong environment.
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -11,7 +11,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh
 
 If any dependency is missing, install it:
 - sift-kg: `uv pip install sift-kg`
-- RDKit (SMILES validation): `uv pip install rdkit-pypi`
+- RDKit (SMILES validation): `uv pip install rdkit`
 - Biopython (sequence validation): `uv pip install biopython`
 
 Report the status of each dependency to the user after running.

--- a/docs/diagrams/v2/architecture.html
+++ b/docs/diagrams/v2/architecture.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Epistract v2.0 Architecture</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'JetBrains Mono', monospace; background: #020617; min-height: 100vh; padding: 2rem; color: white; }
+    .container { max-width: 1280px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot { width: 12px; height: 12px; background: #22d3ee; border-radius: 50%; animation: pulse 2s infinite; }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+    h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.875rem; margin-left: 1.75rem; }
+    .diagram-container { background: rgba(15, 23, 42, 0.5); border-radius: 1rem; border: 1px solid #1e293b; padding: 1.5rem; overflow-x: auto; }
+    svg { width: 100%; min-width: 980px; display: block; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; margin-top: 2rem; }
+    .card { background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem; border: 1px solid #1e293b; padding: 1.25rem; }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card-dot.amber { background: #fbbf24; }
+    .card-dot.rose { background: #fb7185; }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.75rem; }
+    .card li { margin-bottom: 0.375rem; }
+    .footer { text-align: center; margin-top: 1.5rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>Epistract v2.0 — System Architecture</h1>
+      </div>
+      <p class="subtitle">Domain-agnostic knowledge graph framework · three-layer separation · plug-in domain packages</p>
+    </div>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 1000 830">
+        <defs>
+          <marker id="ah" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <marker id="ah-cy" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#22d3ee" />
+          </marker>
+          <marker id="ah-em" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#34d399" />
+          </marker>
+          <marker id="ah-vi" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#a78bfa" />
+          </marker>
+          <marker id="ah-am" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#fbbf24" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- Band 1: Entry -->
+        <rect x="30" y="50" width="110" height="50" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="85" y="73" fill="white" font-size="11" font-weight="600" text-anchor="middle">Users</text>
+        <text x="85" y="89" fill="#94a3b8" font-size="8" text-anchor="middle">Domain developers</text>
+
+        <line x1="140" y1="75" x2="198" y2="75" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#ah-cy)"/>
+
+        <rect x="200" y="50" width="140" height="50" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="270" y="73" fill="white" font-size="11" font-weight="600" text-anchor="middle">Claude Code</text>
+        <text x="270" y="89" fill="#94a3b8" font-size="8" text-anchor="middle">Plugin runtime + CLI</text>
+
+        <line x1="340" y1="75" x2="378" y2="75" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#ah-cy)"/>
+
+        <rect x="380" y="30" width="580" height="90" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="670" y="51" fill="white" font-size="12" font-weight="600" text-anchor="middle">/epistract:* Commands</text>
+        <text x="670" y="68" fill="#94a3b8" font-size="9" text-anchor="middle">12 slash commands · commands/*.md + agents/*.md in .claude-plugin/</text>
+        <text x="670" y="86" fill="#22d3ee" font-size="9" text-anchor="middle">setup · acquire · ingest · build · validate · epistemic · query · view · export · domain · dashboard · ask</text>
+        <text x="670" y="104" fill="#94a3b8" font-size="8" text-anchor="middle">per-document parallel extraction via epistract:extractor subagents</text>
+
+        <!-- Arrow: commands → core -->
+        <line x1="500" y1="120" x2="500" y2="143" stroke="#34d399" stroke-width="1.5" marker-end="url(#ah-em)"/>
+
+        <!-- Band 2: core/ layer -->
+        <rect x="40" y="150" width="920" height="130" rx="10" fill="rgba(6, 78, 59, 0.18)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="60" y="173" fill="#34d399" font-size="12" font-weight="700">core/ — Domain-Agnostic Pipeline Engine</text>
+        <text x="430" y="173" fill="#94a3b8" font-size="9">imports no domain-specific code · same engine runs every domain</text>
+
+        <rect x="60" y="190" width="160" height="72" rx="6" fill="#0f172a"/>
+        <rect x="60" y="190" width="160" height="72" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="140" y="211" fill="white" font-size="10" font-weight="600" text-anchor="middle">domain_resolver</text>
+        <text x="140" y="226" fill="#94a3b8" font-size="8" text-anchor="middle">load domain by name</text>
+        <text x="140" y="240" fill="#94a3b8" font-size="8" text-anchor="middle">return schema + paths</text>
+        <text x="140" y="254" fill="#34d399" font-size="7" text-anchor="middle">aliases · YAML + Pydantic</text>
+
+        <rect x="235" y="190" width="150" height="72" rx="6" fill="#0f172a"/>
+        <rect x="235" y="190" width="150" height="72" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="310" y="211" fill="white" font-size="10" font-weight="600" text-anchor="middle">ingest_documents</text>
+        <text x="310" y="226" fill="#94a3b8" font-size="8" text-anchor="middle">triage · OCR fallback</text>
+        <text x="310" y="240" fill="#94a3b8" font-size="8" text-anchor="middle">per-clause chunking</text>
+        <text x="310" y="254" fill="#34d399" font-size="7" text-anchor="middle">kreuzberg + pdfplumber</text>
+
+        <rect x="400" y="190" width="150" height="72" rx="6" fill="#0f172a"/>
+        <rect x="400" y="190" width="150" height="72" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="475" y="211" fill="white" font-size="10" font-weight="600" text-anchor="middle">build_extraction</text>
+        <text x="475" y="226" fill="#94a3b8" font-size="8" text-anchor="middle">normalize LLM output</text>
+        <text x="475" y="240" fill="#94a3b8" font-size="8" text-anchor="middle">Pydantic validation</text>
+        <text x="475" y="254" fill="#34d399" font-size="7" text-anchor="middle">DocumentExtraction JSON</text>
+
+        <rect x="565" y="190" width="140" height="72" rx="6" fill="#0f172a"/>
+        <rect x="565" y="190" width="140" height="72" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="635" y="211" fill="white" font-size="10" font-weight="600" text-anchor="middle">run_sift</text>
+        <text x="635" y="226" fill="#94a3b8" font-size="8" text-anchor="middle">graph build · resolve</text>
+        <text x="635" y="240" fill="#94a3b8" font-size="8" text-anchor="middle">communities</text>
+        <text x="635" y="254" fill="#34d399" font-size="7" text-anchor="middle">sift-kg wrapper</text>
+
+        <rect x="720" y="190" width="110" height="72" rx="6" fill="#0f172a"/>
+        <rect x="720" y="190" width="110" height="72" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="775" y="211" fill="white" font-size="10" font-weight="600" text-anchor="middle">epistemic</text>
+        <text x="775" y="226" fill="#94a3b8" font-size="8" text-anchor="middle">domain dispatch</text>
+        <text x="775" y="240" fill="#94a3b8" font-size="8" text-anchor="middle">Layer 2 analysis</text>
+        <text x="775" y="254" fill="#34d399" font-size="7" text-anchor="middle">claims.json</text>
+
+        <rect x="845" y="190" width="105" height="72" rx="6" fill="#0f172a"/>
+        <rect x="845" y="190" width="105" height="72" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="897" y="211" fill="white" font-size="10" font-weight="600" text-anchor="middle">wizard</text>
+        <text x="897" y="226" fill="#94a3b8" font-size="8" text-anchor="middle">analyze corpus</text>
+        <text x="897" y="240" fill="#94a3b8" font-size="8" text-anchor="middle">propose schema</text>
+        <text x="897" y="254" fill="#34d399" font-size="7" text-anchor="middle">AST-validated</text>
+
+        <!-- Arrows: core ↔ domains -->
+        <line x1="300" y1="280" x2="300" y2="303" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+        <text x="312" y="296" fill="#a78bfa" font-size="9">resolve_domain()</text>
+
+        <line x1="700" y1="303" x2="700" y2="280" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+        <text x="560" y="296" fill="#a78bfa" font-size="9" text-anchor="end">domain.yaml + SKILL.md + epistemic.py</text>
+
+        <!-- Band 3: domains/ layer -->
+        <rect x="40" y="310" width="920" height="165" rx="10" fill="rgba(76, 29, 149, 0.16)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="60" y="333" fill="#a78bfa" font-size="12" font-weight="700">domains/ — Pluggable Domain Packages</text>
+        <text x="430" y="333" fill="#94a3b8" font-size="9">add a new domain = drop a new package · zero core code changes</text>
+
+        <!-- drug-discovery -->
+        <rect x="70" y="350" width="275" height="115" rx="6" fill="#0f172a"/>
+        <rect x="70" y="350" width="275" height="115" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="207" y="372" fill="white" font-size="11" font-weight="600" text-anchor="middle">drug-discovery/</text>
+        <text x="207" y="387" fill="#94a3b8" font-size="8" text-anchor="middle">biomedical literature analysis</text>
+        <text x="82" y="408" fill="#a78bfa" font-size="8">• domain.yaml</text>
+        <text x="195" y="408" fill="#94a3b8" font-size="8">17 entity types</text>
+        <text x="82" y="422" fill="#a78bfa" font-size="8">• SKILL.md</text>
+        <text x="195" y="422" fill="#94a3b8" font-size="8">30 relation types</text>
+        <text x="82" y="436" fill="#a78bfa" font-size="8">• epistemic.py</text>
+        <text x="195" y="436" fill="#94a3b8" font-size="8">asserted · hypothesized · prophetic</text>
+        <text x="82" y="450" fill="#a78bfa" font-size="8">• validation-scripts/</text>
+        <text x="195" y="450" fill="#94a3b8" font-size="8">RDKit + Biopython</text>
+
+        <!-- contracts -->
+        <rect x="365" y="350" width="275" height="115" rx="6" fill="#0f172a"/>
+        <rect x="365" y="350" width="275" height="115" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="502" y="372" fill="white" font-size="11" font-weight="600" text-anchor="middle">contracts/</text>
+        <text x="502" y="387" fill="#94a3b8" font-size="8" text-anchor="middle">event / vendor contract analysis</text>
+        <text x="377" y="408" fill="#a78bfa" font-size="8">• domain.yaml</text>
+        <text x="490" y="408" fill="#94a3b8" font-size="8">11 entity types</text>
+        <text x="377" y="422" fill="#a78bfa" font-size="8">• SKILL.md</text>
+        <text x="490" y="422" fill="#94a3b8" font-size="8">11 relation types</text>
+        <text x="377" y="436" fill="#a78bfa" font-size="8">• epistemic.py</text>
+        <text x="490" y="436" fill="#94a3b8" font-size="8">critical · warning · info severity</text>
+        <text x="377" y="450" fill="#a78bfa" font-size="8">• workbench/template.yaml</text>
+        <text x="490" y="450" fill="#94a3b8" font-size="8">UI theming</text>
+
+        <!-- your-domain placeholder -->
+        <rect x="660" y="350" width="270" height="115" rx="6" fill="transparent" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="5,4"/>
+        <text x="795" y="372" fill="white" font-size="11" font-weight="600" text-anchor="middle">your-domain/</text>
+        <text x="795" y="387" fill="#94a3b8" font-size="8" text-anchor="middle">any structured document corpus</text>
+        <text x="795" y="413" fill="#a78bfa" font-size="9" text-anchor="middle">generated by</text>
+        <text x="795" y="429" fill="#a78bfa" font-size="10" text-anchor="middle" font-weight="600">/epistract:domain wizard</text>
+        <text x="795" y="449" fill="#94a3b8" font-size="8" text-anchor="middle">analyzes sample corpus → scaffolds package</text>
+
+        <!-- Arrow: domains/core → examples (via artifacts) -->
+        <line x1="500" y1="475" x2="500" y2="498" stroke="#22d3ee" stroke-width="1.5" marker-end="url(#ah-cy)"/>
+        <text x="512" y="491" fill="#22d3ee" font-size="9">graph_data.json · claims.json · communities.json</text>
+
+        <!-- Band 4: examples/ layer -->
+        <rect x="40" y="505" width="920" height="140" rx="10" fill="rgba(8, 51, 68, 0.25)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="60" y="528" fill="#22d3ee" font-size="12" font-weight="700">examples/ — Consumer Applications</text>
+        <text x="430" y="528" fill="#94a3b8" font-size="9">reference consumers · swap domain via --domain flag</text>
+
+        <rect x="70" y="545" width="430" height="90" rx="6" fill="#0f172a"/>
+        <rect x="70" y="545" width="430" height="90" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="285" y="566" fill="white" font-size="11" font-weight="600" text-anchor="middle">workbench/ (FastAPI)</text>
+        <text x="285" y="582" fill="#94a3b8" font-size="8" text-anchor="middle">interactive three-panel dashboard</text>
+        <text x="82" y="601" fill="#22d3ee" font-size="8">• Dashboard</text>
+        <text x="82" y="614" fill="#22d3ee" font-size="8">• Chat panel (SSE)</text>
+        <text x="82" y="627" fill="#22d3ee" font-size="8">• Graph viewer (vis.js)</text>
+        <text x="250" y="601" fill="#94a3b8" font-size="8">domain-specific stats · community breakdown</text>
+        <text x="250" y="614" fill="#94a3b8" font-size="8">SME persona · 3 LLM provider options</text>
+        <text x="250" y="627" fill="#94a3b8" font-size="8">force-directed graph · severity overlays</text>
+
+        <rect x="520" y="545" width="410" height="90" rx="6" fill="#0f172a"/>
+        <rect x="520" y="545" width="410" height="90" rx="6" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="725" y="566" fill="white" font-size="11" font-weight="600" text-anchor="middle">telegram_bot/</text>
+        <text x="725" y="582" fill="#94a3b8" font-size="8" text-anchor="middle">chat with the knowledge graph over Telegram</text>
+        <text x="532" y="601" fill="#22d3ee" font-size="8">• aiogram handlers</text>
+        <text x="532" y="614" fill="#22d3ee" font-size="8">• Bot API polling</text>
+        <text x="532" y="627" fill="#22d3ee" font-size="8">• /start · /ask · /stats</text>
+        <text x="675" y="601" fill="#94a3b8" font-size="8">bridges Telegram messages to workbench chat</text>
+        <text x="675" y="614" fill="#94a3b8" font-size="8">same graph API + LLM provider stack</text>
+        <text x="675" y="627" fill="#94a3b8" font-size="8">HAS_TELEGRAM optional-dependency guard</text>
+
+        <!-- Arrows layers → external (dashed amber) -->
+        <line x1="220" y1="645" x2="220" y2="678" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="5,4" marker-end="url(#ah-am)"/>
+        <line x1="500" y1="645" x2="500" y2="678" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="5,4" marker-end="url(#ah-am)"/>
+        <line x1="780" y1="645" x2="780" y2="678" stroke="#fbbf24" stroke-width="1.5" stroke-dasharray="5,4" marker-end="url(#ah-am)"/>
+
+        <!-- Band 5: External integrations cloud boundary -->
+        <rect x="40" y="685" width="920" height="125" rx="12" fill="rgba(251, 191, 36, 0.04)" stroke="#fbbf24" stroke-width="1" stroke-dasharray="8,4"/>
+        <text x="52" y="703" fill="#fbbf24" font-size="10" font-weight="600">External Integrations</text>
+
+        <rect x="60" y="715" width="150" height="85" rx="6" fill="#0f172a"/>
+        <rect x="60" y="715" width="150" height="85" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="135" y="735" fill="white" font-size="10" font-weight="600" text-anchor="middle">sift-kg ≥0.9.0</text>
+        <text x="135" y="749" fill="#94a3b8" font-size="8" text-anchor="middle">graph engine</text>
+        <text x="70" y="766" fill="#94a3b8" font-size="8">• MultiDiGraph</text>
+        <text x="70" y="778" fill="#94a3b8" font-size="8">• community detection</text>
+        <text x="70" y="790" fill="#94a3b8" font-size="8">• SemHash dedup · pyvis</text>
+
+        <rect x="220" y="715" width="150" height="85" rx="6" fill="#0f172a"/>
+        <rect x="220" y="715" width="150" height="85" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="295" y="735" fill="white" font-size="10" font-weight="600" text-anchor="middle">kreuzberg ≥4.0</text>
+        <text x="295" y="749" fill="#94a3b8" font-size="8" text-anchor="middle">document ingestion</text>
+        <text x="230" y="766" fill="#94a3b8" font-size="8">• 75+ formats</text>
+        <text x="230" y="778" fill="#94a3b8" font-size="8">• PDF · DOCX · PPTX</text>
+        <text x="230" y="790" fill="#94a3b8" font-size="8">• Tesseract OCR fallback</text>
+
+        <!-- LLM Providers security group -->
+        <rect x="390" y="708" width="360" height="100" rx="8" fill="transparent" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <text x="398" y="722" fill="#fb7185" font-size="8">LLM Providers · pluggable via env vars</text>
+
+        <rect x="400" y="730" width="105" height="70" rx="6" fill="#0f172a"/>
+        <rect x="400" y="730" width="105" height="70" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="452" y="750" fill="white" font-size="10" font-weight="600" text-anchor="middle">Anthropic</text>
+        <text x="452" y="764" fill="#94a3b8" font-size="8" text-anchor="middle">direct API</text>
+        <text x="452" y="778" fill="#94a3b8" font-size="8" text-anchor="middle">Claude Sonnet 4.6</text>
+        <text x="452" y="792" fill="#fbbf24" font-size="7" text-anchor="middle">ANTHROPIC_API_KEY</text>
+
+        <rect x="515" y="730" width="115" height="70" rx="6" fill="#0f172a"/>
+        <rect x="515" y="730" width="115" height="70" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="572" y="750" fill="white" font-size="10" font-weight="600" text-anchor="middle">Azure AI Foundry</text>
+        <text x="572" y="764" fill="#94a3b8" font-size="8" text-anchor="middle">enterprise gateway</text>
+        <text x="572" y="778" fill="#94a3b8" font-size="8" text-anchor="middle">standard + custom URL</text>
+        <text x="572" y="792" fill="#fbbf24" font-size="7" text-anchor="middle">ANTHROPIC_FOUNDRY_*</text>
+
+        <rect x="640" y="730" width="100" height="70" rx="6" fill="#0f172a"/>
+        <rect x="640" y="730" width="100" height="70" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="690" y="750" fill="white" font-size="10" font-weight="600" text-anchor="middle">OpenRouter</text>
+        <text x="690" y="764" fill="#94a3b8" font-size="8" text-anchor="middle">model routing</text>
+        <text x="690" y="778" fill="#94a3b8" font-size="8" text-anchor="middle">multi-provider</text>
+        <text x="690" y="792" fill="#fbbf24" font-size="7" text-anchor="middle">OPENROUTER_API_KEY</text>
+
+        <rect x="760" y="715" width="180" height="85" rx="6" fill="#0f172a"/>
+        <rect x="760" y="715" width="180" height="85" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="850" y="735" fill="white" font-size="10" font-weight="600" text-anchor="middle">Optional libs</text>
+        <text x="850" y="749" fill="#94a3b8" font-size="8" text-anchor="middle">domain-specific extras</text>
+        <text x="770" y="766" fill="#94a3b8" font-size="8">• RDKit · SMILES validation</text>
+        <text x="770" y="778" fill="#94a3b8" font-size="8">• Biopython · sequences</text>
+        <text x="770" y="790" fill="#94a3b8" font-size="8">• Tesseract · PubMed E-utils</text>
+
+        <!-- Legend (outside all boundaries, at bottom) -->
+        <text x="40" y="825" fill="#94a3b8" font-size="8">Legend:</text>
+        <rect x="88" y="817" width="12" height="8" rx="2" fill="rgba(8, 51, 68, 0.4)" stroke="#22d3ee" stroke-width="1"/>
+        <text x="104" y="825" fill="#94a3b8" font-size="8">Interface (cyan)</text>
+        <rect x="200" y="817" width="12" height="8" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="216" y="825" fill="#94a3b8" font-size="8">Pipeline (emerald)</text>
+        <rect x="318" y="817" width="12" height="8" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="334" y="825" fill="#94a3b8" font-size="8">Domain packages (violet)</text>
+        <rect x="470" y="817" width="12" height="8" rx="2" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="486" y="825" fill="#94a3b8" font-size="8">External (amber)</text>
+        <rect x="590" y="817" width="12" height="8" rx="2" fill="transparent" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3"/>
+        <text x="606" y="825" fill="#94a3b8" font-size="8">Configurable group (rose)</text>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Three-Layer Principle</h3>
+        </div>
+        <ul>
+          <li>• core/ imports nothing domain-specific</li>
+          <li>• domains/ = domain.yaml + SKILL.md + epistemic.py</li>
+          <li>• examples/ = reference consumers, swappable</li>
+          <li>• Adding a domain = zero core code changes</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Domain Packages (v2.0)</h3>
+        </div>
+        <ul>
+          <li>• drug-discovery — 17 entities · 30 relations · RDKit + Biopython</li>
+          <li>• contracts — 11 entities · 11 relations · severity layer</li>
+          <li>• /epistract:domain wizard scaffolds new packages from sample corpora</li>
+          <li>• AST-validated epistemic.py generation</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot amber"></div>
+          <h3>External Stack</h3>
+        </div>
+        <ul>
+          <li>• sift-kg ≥0.9.0 — MultiDiGraph + community detection</li>
+          <li>• kreuzberg ≥4.0 — 75+ formats + Tesseract OCR</li>
+          <li>• 3 LLM providers pluggable via env vars</li>
+          <li>• Optional: RDKit · Biopython · Tesseract · PubMed E-utils</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footer">Epistract v2.0 · Domain-Agnostic Knowledge Graph Framework · Shipped 2026-04-14 (PR #3 @ cd226de)</p>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/v2/data-flow.html
+++ b/docs/diagrams/v2/data-flow.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Epistract v2.0 Pipeline Data Flow</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'JetBrains Mono', monospace; background: #020617; min-height: 100vh; padding: 2rem; color: white; }
+    .container { max-width: 1280px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot { width: 12px; height: 12px; background: #34d399; border-radius: 50%; animation: pulse 2s infinite; }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+    h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.875rem; margin-left: 1.75rem; }
+    .diagram-container { background: rgba(15, 23, 42, 0.5); border-radius: 1rem; border: 1px solid #1e293b; padding: 1.5rem; overflow-x: auto; }
+    svg { width: 100%; min-width: 980px; display: block; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; margin-top: 2rem; }
+    .card { background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem; border: 1px solid #1e293b; padding: 1.25rem; }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card-dot.amber { background: #fbbf24; }
+    .card-dot.rose { background: #fb7185; }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.75rem; }
+    .card li { margin-bottom: 0.375rem; }
+    .footer { text-align: center; margin-top: 1.5rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>Epistract v2.0 — Pipeline Data Flow</h1>
+      </div>
+      <p class="subtitle">Document corpus → per-document parallel extraction → sift-kg graph build → domain epistemic overlay → artifacts</p>
+    </div>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 1000 820">
+        <defs>
+          <marker id="ah" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <marker id="ah-em" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#34d399" />
+          </marker>
+          <marker id="ah-am" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#fbbf24" />
+          </marker>
+          <marker id="ah-vi" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#a78bfa" />
+          </marker>
+          <marker id="ah-or" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#fb923c" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- Stage 1: Corpus -->
+        <rect x="320" y="30" width="360" height="75" rx="8" fill="#0f172a"/>
+        <rect x="320" y="30" width="360" height="75" rx="8" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <text x="500" y="52" fill="white" font-size="12" font-weight="600" text-anchor="middle">Document Corpus</text>
+        <text x="500" y="70" fill="#94a3b8" font-size="9" text-anchor="middle">PDF · DOCX · PPTX · XLS · HTML · EML · TXT + 75 more</text>
+        <text x="500" y="87" fill="#94a3b8" font-size="9" text-anchor="middle">any size · any domain · local files or PubMed E-utils</text>
+        <text x="500" y="100" fill="#94a3b8" font-size="8" text-anchor="middle">e.g. S6 GLP-1 corpus: 34 documents (patents · papers · clinical trials)</text>
+
+        <line x1="500" y1="105" x2="500" y2="133" stroke="#34d399" stroke-width="1.5" marker-end="url(#ah-em)"/>
+
+        <!-- Stage 2: Ingestion -->
+        <rect x="280" y="135" width="440" height="70" rx="6" fill="#0f172a"/>
+        <rect x="280" y="135" width="440" height="70" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="157" fill="white" font-size="11" font-weight="600" text-anchor="middle">core/ingest_documents.py + kreuzberg</text>
+        <text x="500" y="173" fill="#94a3b8" font-size="8" text-anchor="middle">per-document parse · Tesseract OCR fallback for scanned PDFs</text>
+        <text x="500" y="187" fill="#94a3b8" font-size="8" text-anchor="middle">produces text files + triage metadata (text-native / scanned / mixed)</text>
+        <text x="500" y="201" fill="#34d399" font-size="8" text-anchor="middle">→ ingested/*.txt · ingestion_summary.json</text>
+
+        <!-- Fan-out label -->
+        <text x="500" y="225" fill="#fb923c" font-size="10" font-weight="600" text-anchor="middle">per-document fan-out · N concurrent subagents</text>
+
+        <!-- Fan-out arrows -->
+        <line x1="420" y1="205" x2="180" y2="252" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+        <line x1="470" y1="205" x2="400" y2="252" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+        <line x1="530" y1="205" x2="620" y2="252" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+        <line x1="580" y1="205" x2="840" y2="252" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+
+        <!-- Stage 3: Parallel extractors -->
+        <rect x="30" y="255" width="210" height="115" rx="6" fill="#0f172a"/>
+        <rect x="30" y="255" width="210" height="115" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="135" y="277" fill="white" font-size="10" font-weight="600" text-anchor="middle">epistract:extractor #1</text>
+        <text x="135" y="293" fill="#94a3b8" font-size="8" text-anchor="middle">doc 1 · reads SKILL.md</text>
+        <text x="135" y="307" fill="#94a3b8" font-size="8" text-anchor="middle">applies domain prompts</text>
+        <text x="135" y="321" fill="#94a3b8" font-size="8" text-anchor="middle">extracts entities + relations</text>
+        <text x="135" y="335" fill="#94a3b8" font-size="8" text-anchor="middle">writes JSON via Bash tool</text>
+        <text x="135" y="355" fill="#34d399" font-size="8" text-anchor="middle">→ extractions/doc1.json</text>
+
+        <rect x="255" y="255" width="210" height="115" rx="6" fill="#0f172a"/>
+        <rect x="255" y="255" width="210" height="115" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="360" y="277" fill="white" font-size="10" font-weight="600" text-anchor="middle">epistract:extractor #2</text>
+        <text x="360" y="293" fill="#94a3b8" font-size="8" text-anchor="middle">doc 2 · independent scope</text>
+        <text x="360" y="307" fill="#94a3b8" font-size="8" text-anchor="middle">constrained to schema</text>
+        <text x="360" y="321" fill="#94a3b8" font-size="8" text-anchor="middle">confidence per entity</text>
+        <text x="360" y="335" fill="#94a3b8" font-size="8" text-anchor="middle">evidence text captured</text>
+        <text x="360" y="355" fill="#34d399" font-size="8" text-anchor="middle">→ extractions/doc2.json</text>
+
+        <rect x="480" y="255" width="210" height="115" rx="6" fill="#0f172a"/>
+        <rect x="480" y="255" width="210" height="115" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="585" y="277" fill="white" font-size="10" font-weight="600" text-anchor="middle">epistract:extractor #3</text>
+        <text x="585" y="293" fill="#94a3b8" font-size="8" text-anchor="middle">doc 3 · isolated context</text>
+        <text x="585" y="307" fill="#94a3b8" font-size="8" text-anchor="middle">no cross-doc leakage</text>
+        <text x="585" y="321" fill="#94a3b8" font-size="8" text-anchor="middle">domain-validated types</text>
+        <text x="585" y="335" fill="#94a3b8" font-size="8" text-anchor="middle">Pydantic-shaped output</text>
+        <text x="585" y="355" fill="#34d399" font-size="8" text-anchor="middle">→ extractions/doc3.json</text>
+
+        <rect x="705" y="255" width="265" height="115" rx="6" fill="#0f172a"/>
+        <rect x="705" y="255" width="265" height="115" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <text x="837" y="277" fill="white" font-size="10" font-weight="600" text-anchor="middle">epistract:extractor #N</text>
+        <text x="837" y="293" fill="#94a3b8" font-size="8" text-anchor="middle">scales to 30+ concurrent Claude subagents</text>
+        <text x="837" y="307" fill="#94a3b8" font-size="8" text-anchor="middle">each reads SKILL.md + applies prompts</text>
+        <text x="837" y="321" fill="#94a3b8" font-size="8" text-anchor="middle">extractor scope isolated per document</text>
+        <text x="837" y="335" fill="#94a3b8" font-size="8" text-anchor="middle">no shared context between subagents</text>
+        <text x="837" y="355" fill="#34d399" font-size="8" text-anchor="middle">→ extractions/docN.json</text>
+
+        <!-- Converge arrows -->
+        <line x1="135" y1="370" x2="380" y2="408" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+        <line x1="360" y1="370" x2="440" y2="408" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+        <line x1="585" y1="370" x2="530" y2="408" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+        <line x1="837" y1="370" x2="620" y2="408" stroke="#fb923c" stroke-width="1.5" marker-end="url(#ah-or)"/>
+
+        <!-- Stage 4: build_extraction (merge + validate) -->
+        <rect x="280" y="410" width="440" height="62" rx="6" fill="#0f172a"/>
+        <rect x="280" y="410" width="440" height="62" rx="6" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="500" y="431" fill="white" font-size="11" font-weight="600" text-anchor="middle">core/build_extraction.py</text>
+        <text x="500" y="447" fill="#94a3b8" font-size="8" text-anchor="middle">normalize LLM field names · validate against domain schema (Pydantic)</text>
+        <text x="500" y="463" fill="#34d399" font-size="8" text-anchor="middle">→ DocumentExtraction[] merged into single corpus payload</text>
+
+        <line x1="500" y1="472" x2="500" y2="498" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#ah-am)"/>
+        <text x="512" y="490" fill="#94a3b8" font-size="8">all docs merged</text>
+
+        <!-- Stage 5: sift-kg build -->
+        <rect x="200" y="500" width="600" height="80" rx="6" fill="#0f172a"/>
+        <rect x="200" y="500" width="600" height="80" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="500" y="522" fill="white" font-size="11" font-weight="600" text-anchor="middle">sift-kg graph builder  (core/run_sift.py wrapper)</text>
+        <text x="500" y="539" fill="#94a3b8" font-size="8" text-anchor="middle">canonical naming · SemHash fuzzy dedup · Louvain community detection</text>
+        <text x="500" y="554" fill="#94a3b8" font-size="8" text-anchor="middle">MultiDiGraph construction · per-edge provenance · NetworkX under the hood</text>
+        <text x="500" y="571" fill="#fbbf24" font-size="8" text-anchor="middle">Layer 1: brute facts — nodes + typed edges from documents</text>
+
+        <line x1="500" y1="580" x2="500" y2="606" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+        <text x="512" y="598" fill="#94a3b8" font-size="8">graph_data.json</text>
+
+        <!-- Stage 6: epistemic dispatch -->
+        <rect x="200" y="608" width="600" height="82" rx="6" fill="#0f172a"/>
+        <rect x="200" y="608" width="600" height="82" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="500" y="630" fill="white" font-size="11" font-weight="600" text-anchor="middle">core/epistemic.py → domains/&lt;name&gt;/epistemic.py</text>
+        <text x="500" y="647" fill="#94a3b8" font-size="8" text-anchor="middle">convention-based dispatch via getattr + DOMAIN_ALIASES · domain applies its own rules</text>
+        <text x="500" y="662" fill="#94a3b8" font-size="8" text-anchor="middle">drug-discovery: asserted · hypothesized · prophetic · contradictory  |  contracts: critical · warning · info</text>
+        <text x="500" y="680" fill="#a78bfa" font-size="8" text-anchor="middle">Layer 2: claims — what we infer about the facts</text>
+
+        <!-- Fan-out to artifacts -->
+        <line x1="320" y1="690" x2="160" y2="722" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+        <line x1="440" y1="690" x2="380" y2="722" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+        <line x1="560" y1="690" x2="600" y2="722" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+        <line x1="680" y1="690" x2="830" y2="722" stroke="#a78bfa" stroke-width="1.5" marker-end="url(#ah-vi)"/>
+
+        <!-- Stage 7: Artifacts -->
+        <rect x="60" y="725" width="200" height="62" rx="6" fill="#0f172a"/>
+        <rect x="60" y="725" width="200" height="62" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="160" y="745" fill="white" font-size="10" font-weight="600" text-anchor="middle">graph_data.json</text>
+        <text x="160" y="760" fill="#94a3b8" font-size="8" text-anchor="middle">nodes + edges + attrs</text>
+        <text x="160" y="775" fill="#a78bfa" font-size="8" text-anchor="middle">Layer 1 (brute facts)</text>
+
+        <rect x="280" y="725" width="200" height="62" rx="6" fill="#0f172a"/>
+        <rect x="280" y="725" width="200" height="62" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="380" y="745" fill="white" font-size="10" font-weight="600" text-anchor="middle">claims.json</text>
+        <text x="380" y="760" fill="#94a3b8" font-size="8" text-anchor="middle">status + severity + evidence</text>
+        <text x="380" y="775" fill="#a78bfa" font-size="8" text-anchor="middle">Layer 2 (epistemic)</text>
+
+        <rect x="500" y="725" width="200" height="62" rx="6" fill="#0f172a"/>
+        <rect x="500" y="725" width="200" height="62" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="600" y="745" fill="white" font-size="10" font-weight="600" text-anchor="middle">communities.json</text>
+        <text x="600" y="760" fill="#94a3b8" font-size="8" text-anchor="middle">Louvain clusters</text>
+        <text x="600" y="775" fill="#a78bfa" font-size="8" text-anchor="middle">LLM-narrated labels</text>
+
+        <rect x="720" y="725" width="220" height="62" rx="6" fill="#0f172a"/>
+        <rect x="720" y="725" width="220" height="62" rx="6" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="830" y="745" fill="white" font-size="10" font-weight="600" text-anchor="middle">viz + export</text>
+        <text x="830" y="760" fill="#94a3b8" font-size="8" text-anchor="middle">pyvis .html · GraphML · CSV</text>
+        <text x="830" y="775" fill="#a78bfa" font-size="8" text-anchor="middle">SQLite · JSON · Cytoscape</text>
+
+        <!-- Downstream callout -->
+        <text x="500" y="807" fill="#22d3ee" font-size="9" text-anchor="middle">↓ consumed by examples/workbench · examples/telegram_bot · /epistract:query · /epistract:ask</text>
+
+        <!-- Legend top-right -->
+        <text x="880" y="55" fill="#94a3b8" font-size="8" font-weight="600">Legend</text>
+        <rect x="880" y="62" width="12" height="8" rx="2" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1"/>
+        <text x="896" y="70" fill="#94a3b8" font-size="7">Input</text>
+        <rect x="880" y="75" width="12" height="8" rx="2" fill="rgba(6, 78, 59, 0.4)" stroke="#34d399" stroke-width="1"/>
+        <text x="896" y="83" fill="#94a3b8" font-size="7">Pipeline</text>
+        <rect x="880" y="88" width="12" height="8" rx="2" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="896" y="96" fill="#94a3b8" font-size="7">Graph engine</text>
+        <rect x="880" y="101" width="12" height="8" rx="2" fill="rgba(76, 29, 149, 0.4)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="896" y="109" fill="#94a3b8" font-size="7">Domain / data</text>
+        <line x1="880" y1="118" x2="892" y2="118" stroke="#fb923c" stroke-width="1.5"/>
+        <text x="896" y="122" fill="#94a3b8" font-size="7">Fan-out</text>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Per-Document Parallelism</h3>
+        </div>
+        <ul>
+          <li>• 1 epistract:extractor subagent per document</li>
+          <li>• Each reads SKILL.md + applies domain prompts independently</li>
+          <li>• Scales to 30+ concurrent Claude subagents in practice</li>
+          <li>• Isolated scope — no cross-document context leakage</li>
+          <li>• Emits Pydantic-shaped DocumentExtraction JSON</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot amber"></div>
+          <h3>sift-kg Graph Construction</h3>
+        </div>
+        <ul>
+          <li>• Canonical-name dedup (capital-C → CamelCase)</li>
+          <li>• SemHash fuzzy matching for variants</li>
+          <li>• Louvain community detection + LLM narration</li>
+          <li>• Provenance preserved per edge (source doc + evidence)</li>
+          <li>• MultiDiGraph — supports multiple edges between nodes</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Two-Layer Output</h3>
+        </div>
+        <ul>
+          <li>• Layer 1 — nodes + edges extracted from documents</li>
+          <li>• Layer 2 — claims.json with domain-specific status/severity</li>
+          <li>• Workbench renders both simultaneously</li>
+          <li>• Artifacts are the contract between pipeline and consumers</li>
+          <li>• /epistract:query + /epistract:ask read the same JSON</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footer">Epistract v2.0 · Pipeline Data Flow · verified end-to-end against 6 drug-discovery scenarios (111 documents · +10.7% nodes · +16.2% edges vs V1 baseline)</p>
+  </div>
+</body>
+</html>

--- a/docs/diagrams/v2/two-layer-kg.html
+++ b/docs/diagrams/v2/two-layer-kg.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Epistract v2.0 Two-Layer Knowledge Graph</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'JetBrains Mono', monospace; background: #020617; min-height: 100vh; padding: 2rem; color: white; }
+    .container { max-width: 1280px; margin: 0 auto; }
+    .header { margin-bottom: 2rem; }
+    .header-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.5rem; }
+    .pulse-dot { width: 12px; height: 12px; background: #fb7185; border-radius: 50%; animation: pulse 2s infinite; }
+    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+    h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.025em; }
+    .subtitle { color: #94a3b8; font-size: 0.875rem; margin-left: 1.75rem; }
+    .diagram-container { background: rgba(15, 23, 42, 0.5); border-radius: 1rem; border: 1px solid #1e293b; padding: 1.5rem; overflow-x: auto; }
+    svg { width: 100%; min-width: 980px; display: block; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; margin-top: 2rem; }
+    .card { background: rgba(15, 23, 42, 0.5); border-radius: 0.75rem; border: 1px solid #1e293b; padding: 1.25rem; }
+    .card-header { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; }
+    .card-dot { width: 8px; height: 8px; border-radius: 50%; }
+    .card-dot.cyan { background: #22d3ee; }
+    .card-dot.emerald { background: #34d399; }
+    .card-dot.violet { background: #a78bfa; }
+    .card-dot.amber { background: #fbbf24; }
+    .card-dot.rose { background: #fb7185; }
+    .card h3 { font-size: 0.875rem; font-weight: 600; }
+    .card ul { list-style: none; color: #94a3b8; font-size: 0.75rem; }
+    .card li { margin-bottom: 0.375rem; }
+    .footer { text-align: center; margin-top: 1.5rem; color: #475569; font-size: 0.75rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="header-row">
+        <div class="pulse-dot"></div>
+        <h1>Epistract v2.0 — Two-Layer Knowledge Graph</h1>
+      </div>
+      <p class="subtitle">Layer 1 captures what documents say · Layer 2 captures what we infer about those facts (asserted · hypothesized · prophetic · contradictory · gap)</p>
+    </div>
+
+    <div class="diagram-container">
+      <svg viewBox="0 0 1000 760">
+        <defs>
+          <marker id="ah" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#64748b" />
+          </marker>
+          <marker id="ah-em" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#34d399" />
+          </marker>
+          <marker id="ah-vi" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#a78bfa" />
+          </marker>
+          <marker id="ah-rs" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" fill="#fb7185" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e293b" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- Layer 1 panel (left) -->
+        <rect x="25" y="40" width="475" height="600" rx="10" fill="rgba(6, 78, 59, 0.12)" stroke="#34d399" stroke-width="1.5"/>
+        <text x="45" y="65" fill="#34d399" font-size="13" font-weight="700">Layer 1 — Brute Facts</text>
+        <text x="45" y="80" fill="#94a3b8" font-size="9">nodes + typed edges extracted verbatim from documents</text>
+        <text x="45" y="94" fill="#94a3b8" font-size="8">core/ pipeline + sift-kg graph builder · same for every domain</text>
+
+        <!-- Mini subgraph: KRAS G12C NSCLC (drug-discovery example) -->
+        <!-- Nodes -->
+        <!-- Sotorasib (DRUG = cyan) -->
+        <rect x="70" y="150" width="110" height="44" rx="22" fill="#0f172a"/>
+        <rect x="70" y="150" width="110" height="44" rx="22" fill="rgba(8, 51, 68, 0.5)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="125" y="168" fill="white" font-size="11" font-weight="600" text-anchor="middle">Sotorasib</text>
+        <text x="125" y="183" fill="#22d3ee" font-size="7" text-anchor="middle">DRUG</text>
+
+        <!-- Adagrasib (DRUG = cyan) -->
+        <rect x="70" y="420" width="110" height="44" rx="22" fill="#0f172a"/>
+        <rect x="70" y="420" width="110" height="44" rx="22" fill="rgba(8, 51, 68, 0.5)" stroke="#22d3ee" stroke-width="1.5"/>
+        <text x="125" y="438" fill="white" font-size="11" font-weight="600" text-anchor="middle">Adagrasib</text>
+        <text x="125" y="453" fill="#22d3ee" font-size="7" text-anchor="middle">DRUG</text>
+
+        <!-- KRAS G12C (TARGET = violet) -->
+        <rect x="320" y="280" width="130" height="44" rx="22" fill="#0f172a"/>
+        <rect x="320" y="280" width="130" height="44" rx="22" fill="rgba(76, 29, 149, 0.5)" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="385" y="298" fill="white" font-size="11" font-weight="600" text-anchor="middle">KRAS G12C</text>
+        <text x="385" y="313" fill="#a78bfa" font-size="7" text-anchor="middle">TARGET</text>
+
+        <!-- NSCLC (DISEASE = rose) -->
+        <rect x="320" y="480" width="130" height="44" rx="22" fill="#0f172a"/>
+        <rect x="320" y="480" width="130" height="44" rx="22" fill="rgba(136, 19, 55, 0.5)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="385" y="498" fill="white" font-size="11" font-weight="600" text-anchor="middle">NSCLC</text>
+        <text x="385" y="513" fill="#fb7185" font-size="7" text-anchor="middle">DISEASE</text>
+
+        <!-- FDA (AGENCY = amber) -->
+        <rect x="110" y="580" width="100" height="40" rx="20" fill="#0f172a"/>
+        <rect x="110" y="580" width="100" height="40" rx="20" fill="rgba(120, 53, 15, 0.4)" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="160" y="598" fill="white" font-size="11" font-weight="600" text-anchor="middle">FDA</text>
+        <text x="160" y="613" fill="#fbbf24" font-size="7" text-anchor="middle">AGENCY</text>
+
+        <!-- Edges -->
+        <!-- Sotorasib → KRAS G12C (inhibits) -->
+        <line x1="180" y1="178" x2="318" y2="292" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="225" y="220" fill="#94a3b8" font-size="9">inhibits</text>
+
+        <!-- Adagrasib → KRAS G12C (inhibits) -->
+        <line x1="180" y1="435" x2="318" y2="315" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="225" y="380" fill="#94a3b8" font-size="9">inhibits</text>
+
+        <!-- KRAS G12C → NSCLC (drives) -->
+        <line x1="385" y1="324" x2="385" y2="478" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="397" y="405" fill="#94a3b8" font-size="9">drives</text>
+
+        <!-- Sotorasib → NSCLC (treats, curved) -->
+        <path d="M 125 194 Q 260 330 330 500" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="200" y="350" fill="#94a3b8" font-size="9">treats</text>
+
+        <!-- Adagrasib → NSCLC (treats) -->
+        <line x1="180" y1="450" x2="320" y2="498" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="240" y="488" fill="#94a3b8" font-size="9">treats</text>
+
+        <!-- Sotorasib → FDA (approvedBy) -->
+        <path d="M 95 194 Q 65 380 125 580" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#ah)"/>
+        <text x="40" y="400" fill="#94a3b8" font-size="9">approvedBy</text>
+
+        <!-- Legend for entity types within panel -->
+        <text x="270" y="108" fill="#94a3b8" font-size="8" font-weight="600">Entity types</text>
+        <circle cx="275" cy="122" r="4" fill="rgba(8, 51, 68, 0.5)" stroke="#22d3ee" stroke-width="1"/>
+        <text x="284" y="125" fill="#94a3b8" font-size="7">DRUG</text>
+        <circle cx="315" cy="122" r="4" fill="rgba(76, 29, 149, 0.5)" stroke="#a78bfa" stroke-width="1"/>
+        <text x="324" y="125" fill="#94a3b8" font-size="7">TARGET</text>
+        <circle cx="365" cy="122" r="4" fill="rgba(136, 19, 55, 0.5)" stroke="#fb7185" stroke-width="1"/>
+        <text x="374" y="125" fill="#94a3b8" font-size="7">DISEASE</text>
+        <circle cx="415" cy="122" r="4" fill="rgba(120, 53, 15, 0.4)" stroke="#fbbf24" stroke-width="1"/>
+        <text x="424" y="125" fill="#94a3b8" font-size="7">AGENCY</text>
+
+        <!-- Middle connector -->
+        <text x="500" y="65" fill="#fb7185" font-size="10" font-weight="600" text-anchor="middle">epistemic.py</text>
+        <line x1="500" y1="72" x2="500" y2="610" stroke="#fb7185" stroke-width="1" stroke-dasharray="4,4"/>
+        <text x="500" y="630" fill="#fb7185" font-size="8" text-anchor="middle">domain-specific</text>
+
+        <!-- Multiple rose arrows crossing from Layer 1 to Layer 2 -->
+        <line x1="500" y1="175" x2="528" y2="175" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3" marker-end="url(#ah-rs)"/>
+        <line x1="500" y1="280" x2="528" y2="280" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3" marker-end="url(#ah-rs)"/>
+        <line x1="500" y1="385" x2="528" y2="385" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3" marker-end="url(#ah-rs)"/>
+        <line x1="500" y1="485" x2="528" y2="485" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3" marker-end="url(#ah-rs)"/>
+        <line x1="500" y1="580" x2="528" y2="580" stroke="#fb7185" stroke-width="1" stroke-dasharray="3,3" marker-end="url(#ah-rs)"/>
+
+        <!-- Layer 2 panel (right) -->
+        <rect x="525" y="40" width="450" height="600" rx="10" fill="rgba(136, 19, 55, 0.10)" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="545" y="65" fill="#fb7185" font-size="13" font-weight="700">Layer 2 — Epistemic Overlay</text>
+        <text x="545" y="80" fill="#94a3b8" font-size="9">claims inferred by domains/drug-discovery/epistemic.py</text>
+        <text x="545" y="94" fill="#94a3b8" font-size="8">same subgraph · annotated with status · severity · evidence · confidence</text>
+
+        <!-- Claim 1: asserted -->
+        <rect x="540" y="115" width="420" height="75" rx="6" fill="#0f172a"/>
+        <rect x="540" y="115" width="420" height="75" rx="6" fill="rgba(6, 78, 59, 0.3)" stroke="#34d399" stroke-width="1.5"/>
+        <rect x="550" y="123" width="70" height="14" rx="7" fill="#34d399"/>
+        <text x="585" y="133" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">ASSERTED</text>
+        <text x="630" y="133" fill="#94a3b8" font-size="7">conf 0.95 · 6 sources</text>
+        <text x="555" y="152" fill="white" font-size="10" font-weight="600">Sotorasib → FDA-approved for KRAS G12C NSCLC</text>
+        <text x="555" y="168" fill="#94a3b8" font-size="8">5 clinical-trial papers + FDA label agree · no contradiction</text>
+        <text x="555" y="182" fill="#34d399" font-size="7">evidence: CodeBreaK-100 · KRYSTAL-1 · prescribing information</text>
+
+        <!-- Claim 2: hypothesized -->
+        <rect x="540" y="200" width="420" height="75" rx="6" fill="#0f172a"/>
+        <rect x="540" y="200" width="420" height="75" rx="6" fill="rgba(120, 53, 15, 0.3)" stroke="#fbbf24" stroke-width="1.5"/>
+        <rect x="550" y="208" width="90" height="14" rx="7" fill="#fbbf24"/>
+        <text x="595" y="218" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">HYPOTHESIZED</text>
+        <text x="650" y="218" fill="#94a3b8" font-size="7">conf 0.65 · hedging detected</text>
+        <text x="555" y="237" fill="white" font-size="10" font-weight="600">Sotorasib + SHP2 inhibitor may overcome resistance</text>
+        <text x="555" y="253" fill="#94a3b8" font-size="8">hedging cues in 3 reviews: "might" · "could" · "preliminary evidence suggests"</text>
+        <text x="555" y="267" fill="#fbbf24" font-size="7">regex HEDGING_PATTERNS · flagged, not asserted</text>
+
+        <!-- Claim 3: prophetic -->
+        <rect x="540" y="285" width="420" height="75" rx="6" fill="#0f172a"/>
+        <rect x="540" y="285" width="420" height="75" rx="6" fill="rgba(76, 29, 149, 0.3)" stroke="#a78bfa" stroke-width="1.5"/>
+        <rect x="550" y="293" width="70" height="14" rx="7" fill="#a78bfa"/>
+        <text x="585" y="303" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">PROPHETIC</text>
+        <text x="630" y="303" fill="#94a3b8" font-size="7">source: patent · not peer-reviewed</text>
+        <text x="555" y="322" fill="white" font-size="10" font-weight="600">Patent US 11,000,...23A claims pyrimidine derivatives</text>
+        <text x="555" y="338" fill="#94a3b8" font-size="8">covers sotorasib + adagrasib scaffold · assignee: AMGEN · structural-biology sourced</text>
+        <text x="555" y="352" fill="#a78bfa" font-size="7">PATENT_PATTERN match · stricter handling than peer-reviewed</text>
+
+        <!-- Claim 4: contradictory -->
+        <rect x="540" y="370" width="420" height="80" rx="6" fill="#0f172a"/>
+        <rect x="540" y="370" width="420" height="80" rx="6" fill="rgba(136, 19, 55, 0.35)" stroke="#fb7185" stroke-width="1.5"/>
+        <rect x="550" y="378" width="95" height="14" rx="7" fill="#fb7185"/>
+        <text x="598" y="388" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">CONTRADICTORY</text>
+        <text x="655" y="388" fill="#94a3b8" font-size="7">cross-document conflict detected</text>
+        <text x="555" y="407" fill="white" font-size="10" font-weight="600">ORR reports diverge: 32% (KRYSTAL-1) vs 37% (CodeBreaK-100)</text>
+        <text x="555" y="423" fill="#94a3b8" font-size="8">same drug · similar patient population · 5-point response rate gap</text>
+        <text x="555" y="437" fill="#fb7185" font-size="7">surfaced by cross-doc numeric comparison · flagged for human review</text>
+
+        <!-- Claim 5: gap -->
+        <rect x="540" y="460" width="420" height="70" rx="6" fill="#0f172a"/>
+        <rect x="540" y="460" width="420" height="70" rx="6" fill="rgba(30, 41, 59, 0.5)" stroke="#94a3b8" stroke-width="1.5"/>
+        <rect x="550" y="468" width="40" height="14" rx="7" fill="#94a3b8"/>
+        <text x="570" y="478" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">GAP</text>
+        <text x="600" y="478" fill="#94a3b8" font-size="7">missing relation · potential research priority</text>
+        <text x="555" y="497" fill="white" font-size="10" font-weight="600">No head-to-head Sotorasib vs Adagrasib trial in corpus</text>
+        <text x="555" y="513" fill="#94a3b8" font-size="8">both drugs present · both treat same disease · no comparative study</text>
+        <text x="555" y="525" fill="#94a3b8" font-size="7">graph pattern detector · absent comparativeTo edge</text>
+
+        <!-- Claim 6: multi-hypothesis (drug-discovery specific) -->
+        <rect x="540" y="540" width="420" height="92" rx="6" fill="#0f172a"/>
+        <rect x="540" y="540" width="420" height="92" rx="6" fill="rgba(8, 51, 68, 0.35)" stroke="#22d3ee" stroke-width="1.5" stroke-dasharray="3,3"/>
+        <rect x="550" y="548" width="130" height="14" rx="7" fill="#22d3ee"/>
+        <text x="615" y="558" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">MULTI-HYPOTHESIS</text>
+        <text x="690" y="558" fill="#94a3b8" font-size="7">drug-discovery specific</text>
+        <text x="555" y="577" fill="white" font-size="10" font-weight="600">Resistance mechanism split:</text>
+        <text x="565" y="591" fill="#22d3ee" font-size="8">• Y96C mutation (covalent binding loss)</text>
+        <text x="565" y="603" fill="#22d3ee" font-size="8">• H95Q/R mutation (pocket remodeling)</text>
+        <text x="565" y="615" fill="#22d3ee" font-size="8">• A59S + Y96C (dual-site compensation)</text>
+        <text x="555" y="628" fill="#94a3b8" font-size="7">3 competing hypotheses · divergent confidence · no single mechanism established</text>
+
+        <!-- Bottom: contracts cross-reference -->
+        <rect x="25" y="660" width="950" height="78" rx="10" fill="rgba(76, 29, 149, 0.15)" stroke="#a78bfa" stroke-width="1.5" stroke-dasharray="4,4"/>
+        <text x="45" y="683" fill="#a78bfa" font-size="11" font-weight="700">Same two-layer principle for contracts/ — Layer 2 rules are plugged in, not hard-coded</text>
+        <text x="45" y="702" fill="#94a3b8" font-size="9">contracts/epistemic.py emits severity levels instead of epistemic statuses:</text>
+        <rect x="60" y="712" width="70" height="16" rx="8" fill="#fb7185"/>
+        <text x="95" y="723" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">CRITICAL</text>
+        <text x="138" y="723" fill="#94a3b8" font-size="8">exclusive-use clause conflict · deadline before event date</text>
+        <rect x="460" y="712" width="70" height="16" rx="8" fill="#fbbf24"/>
+        <text x="495" y="723" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">WARNING</text>
+        <text x="538" y="723" fill="#94a3b8" font-size="8">cost overlap · ambiguous scope boundaries</text>
+        <rect x="795" y="712" width="50" height="16" rx="8" fill="#94a3b8"/>
+        <text x="820" y="723" fill="#020617" font-size="8" font-weight="700" text-anchor="middle">INFO</text>
+        <text x="850" y="723" fill="#94a3b8" font-size="8">unsigned drafts · missing dates</text>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Layer 1 — Brute Facts</h3>
+        </div>
+        <ul>
+          <li>• Entities + relations extracted verbatim from documents</li>
+          <li>• Domain schema constrains permitted types</li>
+          <li>• Nodes deduped via canonical name + SemHash fuzzy match</li>
+          <li>• Queryable via /epistract:query + /epistract:view</li>
+          <li>• Same graph-build code runs for every domain</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Layer 2 — Epistemic Claims</h3>
+        </div>
+        <ul>
+          <li>• Asserted — high-confidence factual claims (multiple sources agree)</li>
+          <li>• Hypothesized — hedging language detected in source text</li>
+          <li>• Prophetic — patent-sourced, not peer-reviewed</li>
+          <li>• Contradictory — cross-document conflicts flagged</li>
+          <li>• Gap — expected relations absent from corpus</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot violet"></div>
+          <h3>Domain-Pluggable Layer 2</h3>
+        </div>
+        <ul>
+          <li>• drug-discovery — 4 statuses + multi-hypothesis detection</li>
+          <li>• contracts — Critical · Warning · Info severity instead</li>
+          <li>• New domains plug in epistemic.py with custom rule set</li>
+          <li>• core/epistemic.py dispatches via DOMAIN_ALIASES + getattr</li>
+          <li>• Workbench renders both Layer 1 + Layer 2 as overlays</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="footer">Epistract v2.0 · Two-Layer Knowledge Graph · S6 GLP-1 scenario surfaced 15 prophetic claims from patent corpus (CodeBreaK / KRYSTAL examples shown for illustration)</p>
+  </div>
+</body>
+</html>

--- a/domains/drug-discovery/validation/validate_smiles.py
+++ b/domains/drug-discovery/validation/validate_smiles.py
@@ -29,7 +29,7 @@ def validate_smiles(smiles: str) -> dict:
     if not RDKIT_AVAILABLE:
         return {
             "valid": None,
-            "error": "RDKit not installed. Run: uv pip install rdkit-pypi",
+            "error": "RDKit not installed. Run: uv pip install rdkit",
         }
 
     mol = Chem.MolFromSmiles(smiles)

--- a/domains/drug-discovery/validation/validate_smiles.py
+++ b/domains/drug-discovery/validation/validate_smiles.py
@@ -43,12 +43,14 @@ def validate_smiles(smiles: str) -> dict:
     tpsa = Descriptors.TPSA(mol)
 
     # Lipinski Rule of Five violations
-    violations = sum((
-        mw > 500,
-        logp > 5,
-        hbd > 5,
-        hba > 10,
-    ))
+    violations = sum(
+        (
+            mw > 500,
+            logp > 5,
+            hbd > 5,
+            hba > 10,
+        )
+    )
 
     return {
         "valid": True,

--- a/examples/workbench/api_chat.py
+++ b/examples/workbench/api_chat.py
@@ -207,7 +207,7 @@ async def _stream_anthropic(
     }
 
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(timeout=120.0, proxy=None) as client:
             async with client.stream("POST", base_url, json=payload, headers=headers) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()
@@ -256,7 +256,7 @@ async def _stream_openai_compat(
     }
 
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(timeout=120.0, proxy=None) as client:
             async with client.stream("POST", base_url, json=payload, headers=headers) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()

--- a/examples/workbench/api_chat.py
+++ b/examples/workbench/api_chat.py
@@ -1,4 +1,5 @@
 """Chat API endpoint with LLM SSE streaming."""
+
 from __future__ import annotations
 
 import json
@@ -10,7 +11,10 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
-from examples.workbench.system_prompt import build_system_prompt, get_matched_source_chunks
+from examples.workbench.system_prompt import (
+    build_system_prompt,
+    get_matched_source_chunks,
+)
 
 router = APIRouter(prefix="/api", tags=["chat"])
 
@@ -89,9 +93,8 @@ def _resolve_api_config() -> tuple[str | None, str, str, str]:
     # Accept either AZURE_FOUNDRY_* or ANTHROPIC_FOUNDRY_* naming. We look
     # up both for every field and prefer AZURE_* when both are set (the
     # original naming from the initial Foundry integration).
-    foundry_key = (
-        os.environ.get("AZURE_FOUNDRY_API_KEY")
-        or os.environ.get("ANTHROPIC_FOUNDRY_API_KEY")
+    foundry_key = os.environ.get("AZURE_FOUNDRY_API_KEY") or os.environ.get(
+        "ANTHROPIC_FOUNDRY_API_KEY"
     )
     if foundry_key:
         custom_base = (
@@ -128,11 +131,21 @@ def _resolve_api_config() -> tuple[str | None, str, str, str]:
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        return anthropic_key, "https://api.anthropic.com/v1/messages", "claude-sonnet-4-20250514", "anthropic"
+        return (
+            anthropic_key,
+            "https://api.anthropic.com/v1/messages",
+            "claude-sonnet-4-20250514",
+            "anthropic",
+        )
 
     openrouter_key = os.environ.get("OPENROUTER_API_KEY")
     if openrouter_key:
-        return openrouter_key, "https://openrouter.ai/api/v1/chat/completions", "anthropic/claude-sonnet-4", "openrouter"
+        return (
+            openrouter_key,
+            "https://openrouter.ai/api/v1/chat/completions",
+            "anthropic/claude-sonnet-4",
+            "openrouter",
+        )
 
     return None, "", "", ""
 
@@ -208,10 +221,19 @@ async def _stream_anthropic(
 
     try:
         async with httpx.AsyncClient(timeout=120.0, proxy=None) as client:
-            async with client.stream("POST", base_url, json=payload, headers=headers) as resp:
+            async with client.stream(
+                "POST", base_url, json=payload, headers=headers
+            ) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()
-                    yield {"data": json.dumps({"type": "error", "content": f"API error {resp.status_code}: {body.decode()[:500]}"})}
+                    yield {
+                        "data": json.dumps(
+                            {
+                                "type": "error",
+                                "content": f"API error {resp.status_code}: {body.decode()[:500]}",
+                            }
+                        )
+                    }
                     yield {"data": json.dumps({"type": "done"})}
                     return
 
@@ -227,7 +249,11 @@ async def _stream_anthropic(
                             delta = event.get("delta", {})
                             text = delta.get("text", "")
                             if text:
-                                yield {"data": json.dumps({"type": "text", "content": text})}
+                                yield {
+                                    "data": json.dumps(
+                                        {"type": "text", "content": text}
+                                    )
+                                }
                     except json.JSONDecodeError:
                         continue
     except Exception as e:
@@ -257,10 +283,19 @@ async def _stream_openai_compat(
 
     try:
         async with httpx.AsyncClient(timeout=120.0, proxy=None) as client:
-            async with client.stream("POST", base_url, json=payload, headers=headers) as resp:
+            async with client.stream(
+                "POST", base_url, json=payload, headers=headers
+            ) as resp:
                 if resp.status_code != 200:
                     body = await resp.aread()
-                    yield {"data": json.dumps({"type": "error", "content": f"API error {resp.status_code}: {body.decode()[:500]}"})}
+                    yield {
+                        "data": json.dumps(
+                            {
+                                "type": "error",
+                                "content": f"API error {resp.status_code}: {body.decode()[:500]}",
+                            }
+                        )
+                    }
                     yield {"data": json.dumps({"type": "done"})}
                     return
 
@@ -277,7 +312,11 @@ async def _stream_openai_compat(
                             delta = choices[0].get("delta", {})
                             text = delta.get("content", "")
                             if text:
-                                yield {"data": json.dumps({"type": "text", "content": text})}
+                                yield {
+                                    "data": json.dumps(
+                                        {"type": "text", "content": text}
+                                    )
+                                }
                     except json.JSONDecodeError:
                         continue
     except Exception as e:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -146,13 +146,13 @@ elif [ "$CHECK_ONLY" = true ]; then
   echo "MISSING: RDKit (optional — run 'scripts/setup.sh --all' to install)"
 elif [ "$INSTALL_ALL" = true ]; then
   echo "Installing RDKit via uv..."
-  if uv pip install rdkit-pypi; then
+  if uv pip install rdkit; then
     echo "RDKit installed"
   else
     echo "WARN: RDKit install failed (optional — continuing)"
   fi
 else
-  echo "RDKit not available (optional — install with: uv pip install rdkit-pypi  or re-run with --all)"
+  echo "RDKit not available (optional — install with: uv pip install rdkit  or re-run with --all)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **V2 architecture diagrams** (HTML+SVG, dark theme): `architecture.html`, `data-flow.html`, `two-layer-kg.html` under `docs/diagrams/v2/`
- **Fix: `rdkit-pypi` → `rdkit`** across setup script and docs — `rdkit-pypi` has no wheels for Python 3.13+, while the official `rdkit` package on PyPI does (verified `uv pip install rdkit` → `rdkit==2026.3.1` on Python 3.13.13). Import path is unchanged (`from rdkit import Chem`).
- **Fix: SOCKS proxy bypass in workbench chat** — `examples/workbench/api_chat.py` now passes `proxy=None` to both `httpx.AsyncClient()` calls so corporate VPN environments setting `ALL_PROXY=socks5h://...` no longer break LLM calls. `httpcore 1.0.9` (pinned by sift-kg) lacks bundled SOCKS support, so installing `socksio` doesn't help. `HTTPS_PROXY` (HTTP proxy) inheritance still works since httpx handles HTTP proxies natively.

Both fixes were surfaced while testing in a corporate Azure AI Foundry environment.

## Files changed

| Area | Files |
|---|---|
| Diagrams | `docs/diagrams/v2/{architecture,data-flow,two-layer-kg}.html` |
| `rdkit-pypi` → `rdkit` | `scripts/setup.sh`, `commands/setup.md`, `CLAUDE.md`, `DEVELOPER.md`, `README.md`, `domains/drug-discovery/validation/validate_smiles.py` |
| SOCKS bypass | `examples/workbench/api_chat.py` (lines 223, 285) |

## Test plan

- [x] `uv pip install rdkit` succeeds on Python 3.11, 3.12, 3.13
- [x] `from rdkit import Chem; Chem.MolFromSmiles("CCO")` works after install
- [x] Workbench launches with `ALL_PROXY=socks5h://localhost:1080` set and chat panel sends an LLM call without the `socksio not installed` error
- [x] Workbench still honors `HTTPS_PROXY` for HTTP-proxy environments
- [x] Architecture diagrams render correctly in browser (dark theme, SVG)
- [x] `ruff check` and `ruff format --check` clean on touched Python files

🤖 Generated with [Claude Code](https://claude.com/claude-code)