### PR TITLE
feat(FDA-09): domain-aware community labeling anchors

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,83 @@
+# Roadmap — FDA Product Labels Domain
+
+**Project:** Epistract FDA Product Labels Domain
+**Phases:** 4 | **Requirements:** 9 | **All v1 requirements covered** ✓
+
+## Overview
+
+| # | Phase | Goal | Requirements |
+|---|-------|------|--------------|
+| 1 | Domain Schema & Extraction | Define entity/relation schema and extraction prompt for FDA label knowledge | FDA-01, FDA-02, FDA-03, FDA-04 |
+| 2 | API Integration & Enrichment | Wire open.fda.gov API for corpus acquisition and post-build enrichment | FDA-05, FDA-06, FDA-07 |
+| 3 | Validation & End-to-End Testing | Ingest real FDA labels, build graph, verify coverage and quality | FDA-08 |
+| 4 | Domain-Aware Community Labeling | Make community label generation configurable per domain via domain.yaml anchors | FDA-09 |
+
+---
+
+## Phase 1: Domain Schema & Extraction
+
+**Goal:** A working `domains/fda-labels/` domain package — domain.yaml schema, SKILL.md extraction prompt, and epistemic.py analysis module — that can be loaded by Epistract's domain resolver and used to extract entities and relations from FDA product label text.
+
+**Requirements:** FDA-01, FDA-02, FDA-03, FDA-04
+
+**Success Criteria:**
+1. `domain_resolver.py resolve_domain("fda-labels")` returns valid metadata without errors
+2. `domain.yaml` defines ≥8 entity types and ≥5 relation types with descriptions
+3. `SKILL.md` references FDA label section conventions (indications_and_usage, warnings, adverse_reactions, drug_interactions) and INN naming standards
+4. `epistemic.py` exports `annotate_relations(graph, ...)` function with ≥3 epistemology levels
+5. Domain listed in output of `domain_resolver.list_domains()`
+
+---
+
+## Phase 2: API Integration & Enrichment
+
+**Goal:** A working `enrich.py` that queries open.fda.gov `/drug/label` post-build to annotate Drug nodes with label metadata, plus corpus acquisition support so users can fetch FDA label data before ingestion.
+
+**Requirements:** FDA-05, FDA-06, FDA-07
+
+**Success Criteria:**
+1. `domains/fda-labels/enrich.py` runs without error on a graph built from FDA label extractions
+2. Enrich script enriches ≥1 Drug node with open.fda.gov metadata (application_number or manufacturer name)
+3. Corpus acquisition: running the acquire command with `--domain fda-labels` fetches ≥1 FDA label JSON document from open.fda.gov
+4. `workbench/template.yaml` exists and defines entity_type_colors for Drug, Indication, Warning
+5. `_enrichment_report.json` written to output_dir after enrichment run
+
+---
+
+## Phase 3: Validation & End-to-End Testing
+
+**Goal:** Full end-to-end pipeline verified — ingest sample FDA label documents, build graph, run enrichment, confirm entity/relation coverage meets expectations.
+
+**Requirements:** FDA-08
+
+**Success Criteria:**
+1. Pipeline runs end-to-end: `/epistract:ingest --domain fda-labels` on 3+ sample documents without errors
+2. Built graph contains ≥5 Drug entities with at least 1 relation each
+3. At least 1 Drug entity linked to ≥1 Indication entity and ≥1 Warning entity
+4. Enrichment step completes and adds metadata to ≥1 Drug node
+5. `domain_resolver.py` alias `fda_labels` and `fda` resolve to `fda-labels`
+
+---
+
+## Phase 4: Domain-Aware Community Labeling
+
+**Goal:** Make community label generation configurable per domain by reading a `community_label_anchors` list from each domain's `domain.yaml`. Update `core/label_communities.py` to use anchors instead of hardcoded biomedical/contracts logic. Update `core/domain_wizard.py` to emit `community_label_anchors` for all generated domains. Re-label the fda-product-labels smoke-test graph to verify readable output.
+
+**Requirements:** FDA-09
+
+**Plans:** 2 plans
+
+Plans:
+- [ ] 04-01-PLAN.md — Add anchors to fda-product-labels domain.yaml, refactor label_communities.py with anchor path + backward-compat fallback, update domain_wizard.py to emit anchors
+- [ ] 04-02-PLAN.md — Re-run labeler on fda-smoke-test graph and human-verify readable output
+
+**Success Criteria:**
+1. `domains/fda-product-labels/domain.yaml` contains `community_label_anchors: [DRUG_PRODUCT, ACTIVE_INGREDIENT, INDICATION, MANUFACTURER]`
+2. `core/label_communities.py` reads `community_label_anchors` from domain.yaml when present; falls back to existing logic when absent
+3. Community labels for fda-product-labels graph use drug/ingredient names as anchors (e.g. "Fluconazole", "Risperidone") rather than mechanism descriptions
+4. `core/domain_wizard.py` generates `community_label_anchors` in domain.yaml output for all new domains
+5. Existing domains (drug-discovery, contracts, clinicaltrials) produce unchanged or improved labels after the refactor
+
+---
+
+*Roadmap created: 2026-04-23*

--- a/.planning/phases/04-domain-aware-community-labeling/04-01-PLAN.md
+++ b/.planning/phases/04-domain-aware-community-labeling/04-01-PLAN.md
@@ -1,0 +1,654 @@
+---
+phase: 04-domain-aware-community-labeling
+plan: "01"
+type: tdd
+wave: 1
+depends_on: []
+files_modified:
+  - domains/fda-product-labels/domain.yaml
+  - core/label_communities.py
+  - core/domain_wizard.py
+  - tests/test_unit.py
+autonomous: true
+requirements:
+  - FDA-09
+
+must_haves:
+  truths:
+    - "label_communities.py reads community_label_anchors from domain.yaml when present and uses first-matching anchor type as label source"
+    - "label_communities.py falls back to existing _generate_label logic when community_label_anchors is absent"
+    - "domains/fda-product-labels/domain.yaml contains community_label_anchors: [DRUG_PRODUCT, ACTIVE_INGREDIENT, INDICATION, MANUFACTURER]"
+    - "domain_wizard.py emits community_label_anchors in generated domain.yaml"
+    - "anchor labels are truncated at 40 chars with ellipsis, title-cased, underscores replaced with spaces"
+    - "multi-anchor format: '{first} / {second}' for 2, '{first} + {N-1} more' for 3+"
+  artifacts:
+    - path: "domains/fda-product-labels/domain.yaml"
+      provides: "community_label_anchors list field"
+      contains: "community_label_anchors"
+    - path: "core/label_communities.py"
+      provides: "anchor-aware labeling with backward-compat fallback"
+      exports: ["label_communities", "_generate_label", "_anchor_label"]
+    - path: "core/domain_wizard.py"
+      provides: "community_label_anchors emission in generate_domain_yaml"
+      contains: "community_label_anchors"
+    - path: "tests/test_unit.py"
+      provides: "unit tests for anchor path, fallback path, format edge cases"
+      contains: "test_fda09"
+  key_links:
+    - from: "core/label_communities.py:label_communities()"
+      to: "graph_data.json metadata.domain"
+      via: "reads domain name, resolves domain.yaml via core.domain_resolver.resolve_domain"
+      pattern: "metadata.*domain"
+    - from: "core/label_communities.py:_anchor_label()"
+      to: "community_label_anchors list in domain.yaml"
+      via: "schema dict key lookup"
+      pattern: "community_label_anchors"
+    - from: "core/domain_wizard.py:generate_domain_yaml()"
+      to: "community_label_anchors parameter"
+      via: "schema dict construction before yaml.safe_dump"
+      pattern: "community_label_anchors"
+---
+
+<objective>
+Implement config-driven community labeling anchors: add `community_label_anchors` to
+`domains/fda-product-labels/domain.yaml`, refactor `core/label_communities.py` to read
+and use anchors (with backward-compatible fallback), and update `core/domain_wizard.py`
+to emit anchors for generated domains.
+
+Purpose: Replace verbose mechanism-name labels ("Ace Inhibition Of Angiotensin-Converting
+Enzyme / Ampa/Kainate...") with human-readable drug/ingredient names ("Fluconazole",
+"Risperidone") for fda-product-labels graphs, without breaking existing domain labeling.
+
+Output:
+- `domains/fda-product-labels/domain.yaml` updated with `community_label_anchors`
+- `core/label_communities.py` with new `_anchor_label()` and `_load_domain_anchors()` functions
+- `core/domain_wizard.py` with `community_label_anchors` parameter in `generate_domain_yaml`
+- Unit tests covering anchor path, fallback path, truncation, multi-anchor format
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@core/label_communities.py
+@core/domain_wizard.py
+@core/domain_resolver.py
+@domains/fda-product-labels/domain.yaml
+
+<interfaces>
+<!-- Key types the executor needs. Extracted from codebase. -->
+
+From core/domain_resolver.py:
+```python
+def resolve_domain(name: str | None = None) -> dict:
+    # Returns: {"name", "dir", "yaml_path", "skill_path", "schema", "validation_dir"}
+    # schema is yaml.safe_load(domain.yaml) — a plain dict
+    # schema["community_label_anchors"] will be a list[str] when present
+
+DOMAINS_DIR: Path  # .../domains/
+```
+
+From core/label_communities.py (current signatures):
+```python
+def label_communities(output_dir: Path) -> dict:
+    # Reads: output_dir/communities.json, output_dir/graph_data.json
+    # graph_data["metadata"]["domain"] -> domain name string e.g. "fda-product-labels"
+    # Returns: label_map (old_name -> new_name)
+
+def _generate_label(members: list[dict]) -> str:
+    # members: list of node dicts with keys "name", "entity_type"
+    # Current: hardcoded biomedical + contracts domain detection
+
+def _top_entities(members: list[dict], n: int = 5) -> list[str]:
+    # Returns top-N entity names by priority
+```
+
+From core/domain_wizard.py (current generate_domain_yaml signature):
+```python
+def generate_domain_yaml(
+    domain_name: str,
+    description: str,
+    system_context: str,
+    entity_types: dict,
+    relation_types: dict,
+) -> str:
+    # Builds schema dict, calls yaml.safe_dump
+    # community_label_anchors must be added as optional parameter
+
+def generate_domain_package(
+    domain_name: str,
+    domain_slug: str,
+    description: str,
+    system_context: str,
+    entity_types: dict,
+    relation_types: dict,
+    extraction_guidelines: str,
+    contradiction_pairs: list[tuple[str, str]] | None = None,
+    gap_target_types: dict | None = None,
+    confidence_thresholds: dict | None = None,
+    persona: str | None = None,
+) -> dict:
+```
+
+graph_data.json structure (confirmed from smoke-test):
+```json
+{
+  "metadata": {
+    "domain": "fda-product-labels",
+    "created_at": "2026-04-23T18:14:48.907585"
+  },
+  "nodes": [
+    {"id": "drug_product:fluconazole", "name": "Fluconazole", "entity_type": "DRUG_PRODUCT"}
+  ]
+}
+```
+
+communities.json structure (before labeling):
+```json
+{
+  "drug_product:fluconazole": "community_0",
+  "active_ingredient:fluconazole_api": "community_0"
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add community_label_anchors to fda-product-labels domain.yaml</name>
+  <files>domains/fda-product-labels/domain.yaml, tests/test_unit.py</files>
+  <read_first>
+    - domains/fda-product-labels/domain.yaml (full file — understand current structure and last key)
+    - tests/test_unit.py lines 2431-2480 (ctdm test pattern for domain yaml assertions)
+  </read_first>
+  <behavior>
+    - Test RED: load fda-product-labels domain.yaml, assert `community_label_anchors` key exists — MUST FAIL before edit
+    - Test: assert value equals ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION", "MANUFACTURER"] (exact order)
+    - Test: assert all 4 anchor values exist as keys in domain.yaml `entity_types`
+  </behavior>
+  <action>
+Write two unit tests to `tests/test_unit.py` first (append after the last test at line ~2591):
+
+```python
+# --- FDA-09: community_label_anchors ---
+
+
+def test_fda09_domain_yaml_has_anchors():
+    """FDA-09 SC1: fda-product-labels domain.yaml contains community_label_anchors list."""
+    import yaml
+    from core.domain_resolver import DOMAINS_DIR
+
+    yaml_path = DOMAINS_DIR / "fda-product-labels" / "domain.yaml"
+    schema = yaml.safe_load(yaml_path.read_text())
+    assert "community_label_anchors" in schema, "community_label_anchors missing from domain.yaml"
+    anchors = schema["community_label_anchors"]
+    assert anchors == ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION", "MANUFACTURER"]
+
+
+def test_fda09_anchor_types_exist_in_entity_types():
+    """FDA-09: all anchor types must be defined entity_types in the schema."""
+    import yaml
+    from core.domain_resolver import DOMAINS_DIR
+
+    yaml_path = DOMAINS_DIR / "fda-product-labels" / "domain.yaml"
+    schema = yaml.safe_load(yaml_path.read_text())
+    entity_type_names = set(schema.get("entity_types", {}).keys())
+    for anchor in schema["community_label_anchors"]:
+        assert anchor in entity_type_names, f"Anchor {anchor!r} not found in entity_types"
+```
+
+Run tests (RED — both fail). Then edit `domains/fda-product-labels/domain.yaml`:
+
+Append to the end of the file, after the last `relation_types` entry (after the
+`CONTRAINDICATED_WITH` block), as a new top-level key:
+
+```yaml
+community_label_anchors:
+  - DRUG_PRODUCT
+  - ACTIVE_INGREDIENT
+  - INDICATION
+  - MANUFACTURER
+```
+
+Run tests again (GREEN — both pass).
+  </action>
+  <verify>
+    <automated>cd /home/chrisdavidson/programming/epistract && python -m pytest tests/test_unit.py::test_fda09_domain_yaml_has_anchors tests/test_unit.py::test_fda09_anchor_types_exist_in_entity_types -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep "community_label_anchors" /home/chrisdavidson/programming/epistract/domains/fda-product-labels/domain.yaml` returns at least 1 match
+    - `grep -A4 "community_label_anchors" /home/chrisdavidson/programming/epistract/domains/fda-product-labels/domain.yaml` shows DRUG_PRODUCT, ACTIVE_INGREDIENT, INDICATION, MANUFACTURER in that order
+    - Both test_fda09_domain_yaml_has_anchors and test_fda09_anchor_types_exist_in_entity_types pass
+  </acceptance_criteria>
+  <done>Both test_fda09_* YAML tests pass. domain.yaml contains `community_label_anchors` as the last top-level key with exactly 4 entries in the specified order.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Refactor label_communities.py with anchor-based label path</name>
+  <files>core/label_communities.py, tests/test_unit.py</files>
+  <read_first>
+    - core/label_communities.py (full file — current _generate_label, _top_entities, label_communities)
+    - core/domain_resolver.py lines 89-127 (resolve_domain return shape)
+    - tests/test_unit.py lines 1710-1720 (existing label_communities usage)
+  </read_first>
+  <behavior>
+    - Test _anchor_label single match: members=[{name:"Fluconazole", entity_type:"DRUG_PRODUCT"}], anchors=["DRUG_PRODUCT","ACTIVE_INGREDIENT"] → "Fluconazole"
+    - Test _anchor_label two matches slash format: 2 DRUG_PRODUCT members "Aspirin" + "Ibuprofen", anchors=["DRUG_PRODUCT"] → "Aspirin / Ibuprofen"
+    - Test _anchor_label three+ more format: 3 DRUG_PRODUCT members "Alpha","Beta","Gamma" → "Alpha + 2 more"
+    - Test _anchor_label truncation: name of 50 chars → result ends with "…" and len == 41 (40 + ellipsis)
+    - Test _anchor_label priority fallback: no DRUG_PRODUCT present, ACTIVE_INGREDIENT present → uses ACTIVE_INGREDIENT
+    - Test _anchor_label no match: members all have entity_type not in anchors → returns None
+    - Test backward compat — missing anchors: label_communities() with _load_domain_anchors monkeypatched to [] → no crash, returns dict
+    - Test backward compat — missing metadata: graph_data.json with no metadata.domain key → no crash, returns dict
+  </behavior>
+  <action>
+Write all unit tests to `tests/test_unit.py` first (append after Task 1's tests). Run them (RED). Then implement in `core/label_communities.py`. Run tests (GREEN).
+
+**Tests to add:**
+
+```python
+# --- FDA-09: _anchor_label() unit tests ---
+
+
+def test_fda09_anchor_label_single_match():
+    from core.label_communities import _anchor_label
+
+    members = [{"name": "Fluconazole", "entity_type": "DRUG_PRODUCT"}]
+    anchors = ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION"]
+    assert _anchor_label(members, anchors) == "Fluconazole"
+
+
+def test_fda09_anchor_label_two_matches_slash():
+    from core.label_communities import _anchor_label
+
+    members = [
+        {"name": "Aspirin", "entity_type": "DRUG_PRODUCT"},
+        {"name": "Ibuprofen", "entity_type": "DRUG_PRODUCT"},
+    ]
+    result = _anchor_label(members, ["DRUG_PRODUCT"])
+    assert result == "Aspirin / Ibuprofen"
+
+
+def test_fda09_anchor_label_three_plus_more():
+    from core.label_communities import _anchor_label
+
+    members = [
+        {"name": "Alpha", "entity_type": "DRUG_PRODUCT"},
+        {"name": "Beta", "entity_type": "DRUG_PRODUCT"},
+        {"name": "Gamma", "entity_type": "DRUG_PRODUCT"},
+    ]
+    result = _anchor_label(members, ["DRUG_PRODUCT"])
+    assert result == "Alpha + 2 more"
+
+
+def test_fda09_anchor_label_truncation():
+    from core.label_communities import _anchor_label
+
+    long_name = "A" * 50  # 50 chars; _clean_name title-cases but 'A'*50 stays 50 'A's
+    members = [{"name": long_name, "entity_type": "DRUG_PRODUCT"}]
+    result = _anchor_label(members, ["DRUG_PRODUCT"])
+    assert result is not None
+    assert result.endswith("…"), f"Expected ellipsis suffix, got: {result!r}"
+    assert len(result) == 41  # 40 chars + 1 ellipsis char
+
+
+def test_fda09_anchor_label_priority_fallback():
+    """DRUG_PRODUCT absent; falls back to ACTIVE_INGREDIENT."""
+    from core.label_communities import _anchor_label
+
+    members = [{"name": "Fluoxetine", "entity_type": "ACTIVE_INGREDIENT"}]
+    result = _anchor_label(members, ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION"])
+    assert result == "Fluoxetine"
+
+
+def test_fda09_anchor_label_no_match_returns_none():
+    from core.label_communities import _anchor_label
+
+    members = [
+        {"name": "Some Mechanism", "entity_type": "MECHANISM_OF_ACTION"},
+        {"name": "500mg Tablet Daily", "entity_type": "DOSAGE_REGIMEN"},
+    ]
+    result = _anchor_label(members, ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION"])
+    assert result is None
+
+
+def test_fda09_backward_compat_no_anchors(tmp_path, monkeypatch):
+    """Domains without community_label_anchors must use _generate_label (no crash)."""
+    import json
+    import core.label_communities as lc
+
+    monkeypatch.setattr(lc, "_load_domain_anchors", lambda gd: [])
+
+    communities = {"gene:tp53": "community_0"}
+    graph_data = {
+        "metadata": {"domain": "drug-discovery"},
+        "nodes": [{"id": "gene:tp53", "name": "TP53", "entity_type": "GENE"}],
+    }
+    (tmp_path / "communities.json").write_text(json.dumps(communities))
+    (tmp_path / "graph_data.json").write_text(json.dumps(graph_data))
+
+    result = lc.label_communities(tmp_path)
+    assert isinstance(result, dict)
+    assert len(result) == 1
+
+
+def test_fda09_backward_compat_missing_domain_metadata(tmp_path):
+    """graph_data.json with no metadata.domain -> _generate_label fallback (no crash)."""
+    import json
+    import core.label_communities as lc
+
+    communities = {"gene:brca1": "community_0"}
+    graph_data = {
+        "nodes": [{"id": "gene:brca1", "name": "BRCA1", "entity_type": "GENE"}],
+    }
+    (tmp_path / "communities.json").write_text(json.dumps(communities))
+    (tmp_path / "graph_data.json").write_text(json.dumps(graph_data))
+
+    result = lc.label_communities(tmp_path)
+    assert isinstance(result, dict)
+```
+
+**Implementation changes to `core/label_communities.py`:**
+
+Add `import yaml` at the top with existing imports (yaml is already available as a dependency).
+
+Add `_anchor_label()` function between `_top_entities` and `_generate_label`:
+
+```python
+def _anchor_label(members: list[dict], anchors: list[str]) -> str | None:
+    """Generate a community label using domain-configured anchor entity types.
+
+    Walks the priority list (anchors) in order; first anchor type that has
+    at least one member in the community becomes the label source.
+
+    Args:
+        members: List of node dicts with keys "name" and "entity_type".
+        anchors: Ordered priority list of entity type names from domain.yaml
+                 community_label_anchors. First match wins.
+
+    Returns:
+        Label string if any anchor matches, else None (caller falls back to
+        _generate_label for backward compatibility).
+    """
+    MAX_NAME_LEN = 40
+
+    def _truncate(name: str) -> str:
+        cleaned = _clean_name(name)
+        return cleaned[:MAX_NAME_LEN] + "…" if len(cleaned) > MAX_NAME_LEN else cleaned
+
+    for anchor_type in anchors:
+        matched = [m for m in members if m.get("entity_type") == anchor_type]
+        if not matched:
+            continue
+        names = [_truncate(m["name"]) for m in matched]
+        if len(names) == 1:
+            return names[0]
+        if len(names) == 2:
+            return f"{names[0]} / {names[1]}"
+        return f"{names[0]} + {len(names) - 1} more"
+    return None
+```
+
+Note: `_anchor_label` calls `_clean_name` which is defined later in the file. In Python,
+this is fine at call-time (not at definition-time). If linters complain, move `_clean_name`
+above `_anchor_label`.
+
+Add `_load_domain_anchors()` function after `_anchor_label`:
+
+```python
+def _load_domain_anchors(graph_data: dict) -> list[str]:
+    """Load community_label_anchors from the domain yaml referenced by graph_data.
+
+    Reads metadata.domain from graph_data, resolves the domain via
+    core.domain_resolver.resolve_domain, and returns community_label_anchors.
+    Returns empty list on any failure to preserve backward compatibility.
+
+    Args:
+        graph_data: Parsed graph_data.json dict.
+
+    Returns:
+        List of anchor entity type names, or [] if not configured or on error.
+    """
+    try:
+        from core.domain_resolver import resolve_domain
+
+        domain_name = graph_data.get("metadata", {}).get("domain")
+        if not domain_name:
+            return []
+        info = resolve_domain(domain_name)
+        schema = info.get("schema") or {}
+        anchors = schema.get("community_label_anchors", [])
+        return anchors if isinstance(anchors, list) else []
+    except Exception:
+        return []
+```
+
+In `label_communities()`, after the existing `node_lookup` population block and before
+the `community_members` dict construction, add:
+
+```python
+    # Load domain-configured label anchors (FDA-09). Returns [] when
+    # community_label_anchors is absent from domain.yaml (backward compat).
+    domain_anchors = _load_domain_anchors(graph_data)
+```
+
+In the label generation loop, replace:
+```python
+        label = _generate_label(members)
+```
+with:
+```python
+        if domain_anchors:
+            label = _anchor_label(members, domain_anchors) or _generate_label(members)
+        else:
+            label = _generate_label(members)
+```
+  </action>
+  <verify>
+    <automated>cd /home/chrisdavidson/programming/epistract && python -m pytest tests/test_unit.py -k "test_fda09" -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep "_anchor_label" /home/chrisdavidson/programming/epistract/core/label_communities.py` returns at least 2 lines (definition + call site)
+    - `grep "_load_domain_anchors" /home/chrisdavidson/programming/epistract/core/label_communities.py` returns at least 2 lines (definition + call site)
+    - `grep "domain_anchors" /home/chrisdavidson/programming/epistract/core/label_communities.py` returns at least 2 lines (assignment + conditional)
+    - All test_fda09_anchor_label_* and test_fda09_backward_compat_* tests pass
+  </acceptance_criteria>
+  <done>
+All test_fda09_anchor_label_* and test_fda09_backward_compat_* tests pass. core/label_communities.py contains _anchor_label(), _load_domain_anchors(), and updated label_communities() dispatch logic.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Update domain_wizard.py to emit community_label_anchors</name>
+  <files>core/domain_wizard.py, tests/test_unit.py</files>
+  <read_first>
+    - core/domain_wizard.py lines 414-446 (generate_domain_yaml — current signature and schema dict)
+    - core/domain_wizard.py lines 1052-1139 (generate_domain_package — passes kwargs to generate_domain_yaml)
+    - tests/test_unit.py lines 2226-2278 (test_wizard_schema_bypass_skips_llm — test pattern to follow)
+  </read_first>
+  <behavior>
+    - Test: generate_domain_yaml with community_label_anchors=["TYPE_A","TYPE_B"] → YAML string parses to dict with community_label_anchors == ["TYPE_A","TYPE_B"]
+    - Test: generate_domain_yaml without community_label_anchors → parsed YAML does NOT contain "community_label_anchors" key
+  </behavior>
+  <action>
+Append two tests to `tests/test_unit.py` after Task 2's tests (RED phase). Then implement (GREEN).
+
+**Tests to add:**
+
+```python
+# --- FDA-09: domain_wizard community_label_anchors emission ---
+
+
+def test_fda09_wizard_generate_domain_yaml_with_anchors():
+    """generate_domain_yaml with anchors emits community_label_anchors in YAML."""
+    import yaml
+    from core.domain_wizard import generate_domain_yaml
+
+    result = generate_domain_yaml(
+        domain_name="Test Domain",
+        description="A test domain",
+        system_context="Extract test entities",
+        entity_types={"FOO": {"description": "Foo entity"}},
+        relation_types={"HAS_FOO": {"description": "Has foo"}},
+        community_label_anchors=["FOO"],
+    )
+    parsed = yaml.safe_load(result)
+    assert "community_label_anchors" in parsed, "anchors missing from generated YAML"
+    assert parsed["community_label_anchors"] == ["FOO"]
+
+
+def test_fda09_wizard_generate_domain_yaml_without_anchors():
+    """generate_domain_yaml without anchors does NOT emit community_label_anchors (backward compat)."""
+    import yaml
+    from core.domain_wizard import generate_domain_yaml
+
+    result = generate_domain_yaml(
+        domain_name="Test Domain",
+        description="A test domain",
+        system_context="Extract test entities",
+        entity_types={"FOO": {"description": "Foo entity"}},
+        relation_types={"HAS_FOO": {"description": "Has foo"}},
+    )
+    parsed = yaml.safe_load(result)
+    assert "community_label_anchors" not in parsed, (
+        "community_label_anchors should be absent when not provided"
+    )
+```
+
+**Implementation in `core/domain_wizard.py`:**
+
+Update `generate_domain_yaml()` signature from:
+```python
+def generate_domain_yaml(
+    domain_name: str,
+    description: str,
+    system_context: str,
+    entity_types: dict,
+    relation_types: dict,
+) -> str:
+```
+to:
+```python
+def generate_domain_yaml(
+    domain_name: str,
+    description: str,
+    system_context: str,
+    entity_types: dict,
+    relation_types: dict,
+    community_label_anchors: list[str] | None = None,
+) -> str:
+```
+
+Update the schema dict construction inside `generate_domain_yaml()`. After building the
+`schema` dict and before calling `yaml.safe_dump`, add the conditional insertion:
+
+```python
+    schema = {
+        "name": domain_name,
+        "version": "1.0.0",
+        "description": description,
+        "system_context": system_context,
+        "entity_types": entity_types,
+        "relation_types": relation_types,
+    }
+    if community_label_anchors is not None:
+        schema["community_label_anchors"] = community_label_anchors
+    return yaml.safe_dump(
+        schema,
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+```
+
+Update `generate_domain_package()` signature — add after `confidence_thresholds` parameter:
+```python
+    community_label_anchors: list[str] | None = None,
+```
+
+Update the `generate_domain_yaml(...)` call inside `generate_domain_package()` to pass through:
+```python
+    domain_yaml = generate_domain_yaml(
+        domain_name, description, system_context, entity_types, relation_types,
+        community_label_anchors=community_label_anchors,
+    )
+```
+  </action>
+  <verify>
+    <automated>cd /home/chrisdavidson/programming/epistract && python -m pytest tests/test_unit.py -k "test_fda09" -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep "community_label_anchors" /home/chrisdavidson/programming/epistract/core/domain_wizard.py` returns at least 3 lines (parameter, conditional, pass-through in generate_domain_package)
+    - test_fda09_wizard_generate_domain_yaml_with_anchors passes
+    - test_fda09_wizard_generate_domain_yaml_without_anchors passes
+    - Full test suite shows no regressions: `python -m pytest tests/test_unit.py -x -q 2>&1 | tail -5` shows 0 failures
+  </acceptance_criteria>
+  <done>
+All test_fda09_wizard_* tests pass. generate_domain_yaml() accepts community_label_anchors as optional kwarg. YAML output includes the key when provided; omits it when absent. Full test_unit.py suite passes with 0 failures.
+  </done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| domain.yaml -> label_communities.py | YAML parsed via yaml.safe_load; community_label_anchors values used only for dict-key string comparison in _anchor_label() — no eval, no execution |
+| graph_data.json metadata.domain -> resolve_domain | Domain name string used as path component inside DOMAINS_DIR; existing _resolve_domain_dir raises FileNotFoundError on unknown names, caught by _load_domain_anchors try/except |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-01 | Tampering | community_label_anchors in domain.yaml | accept | Values used only for entity_type string comparison; no code execution path; worst case is wrong labels, not a security impact |
+| T-04-02 | Information Disclosure | _load_domain_anchors exception swallowing | mitigate | Catch-all `except Exception: return []` prevents stack trace leakage; function never surfaces internal paths or credentials |
+| T-04-03 | Denial of Service | malformed community_label_anchors (non-list type in YAML) | mitigate | `isinstance(anchors, list)` guard in _load_domain_anchors() returns [] on non-list values, preventing AttributeError crash downstream |
+</threat_model>
+
+<verification>
+Run all FDA-09 tests after all three tasks complete:
+
+```bash
+cd /home/chrisdavidson/programming/epistract && python -m pytest tests/test_unit.py -k "test_fda09" -v
+```
+
+Expected: 12 test_fda09_* tests, 0 failures.
+
+Run full regression:
+```bash
+cd /home/chrisdavidson/programming/epistract && python -m pytest tests/test_unit.py -x -q 2>&1 | tail -5
+```
+
+Expected: 0 failures, no deselected tests.
+
+Verify domain.yaml structure:
+```bash
+cd /home/chrisdavidson/programming/epistract && python3 -c "
+import yaml
+from core.domain_resolver import DOMAINS_DIR
+s = yaml.safe_load((DOMAINS_DIR / 'fda-product-labels' / 'domain.yaml').read_text())
+print('anchors:', s['community_label_anchors'])
+"
+```
+
+Expected output: `anchors: ['DRUG_PRODUCT', 'ACTIVE_INGREDIENT', 'INDICATION', 'MANUFACTURER']`
+</verification>
+
+<success_criteria>
+- `domains/fda-product-labels/domain.yaml` contains `community_label_anchors` as the last top-level key with value [DRUG_PRODUCT, ACTIVE_INGREDIENT, INDICATION, MANUFACTURER]
+- `core/label_communities.py` exports `_anchor_label()`, `_load_domain_anchors()`, and updated `label_communities()` with anchor-dispatch logic
+- `core/domain_wizard.py:generate_domain_yaml()` accepts `community_label_anchors: list[str] | None = None` and emits the key when provided
+- All 12 test_fda09_* tests pass
+- Full test_unit.py suite passes with 0 regressions
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-domain-aware-community-labeling/04-01-SUMMARY.md`
+</output>

--- a/.planning/phases/04-domain-aware-community-labeling/04-01-SUMMARY.md
+++ b/.planning/phases/04-domain-aware-community-labeling/04-01-SUMMARY.md
@@ -1,0 +1,114 @@
+---
+phase: 04-domain-aware-community-labeling
+plan: "01"
+subsystem: community-labeling
+tags: [fda-product-labels, community-labeling, domain-config, tdd, backward-compat]
+dependency_graph:
+  requires: []
+  provides:
+    - domains/fda-product-labels/domain.yaml:community_label_anchors
+    - core/label_communities.py:_anchor_label
+    - core/label_communities.py:_load_domain_anchors
+    - core/domain_wizard.py:generate_domain_yaml:community_label_anchors
+  affects:
+    - core/run_sift.py (calls label_communities — now anchor-aware for fda-product-labels)
+tech_stack:
+  added: []
+  patterns:
+    - config-driven behavior (community_label_anchors in domain.yaml drives label strategy)
+    - backward-compatible optional parameter (None default — key omitted)
+    - catch-all exception swallow in _load_domain_anchors for resilience
+key_files:
+  created:
+    - domains/fda-product-labels/domain.yaml
+  modified:
+    - core/label_communities.py
+    - core/domain_wizard.py
+    - tests/test_unit.py
+decisions:
+  - anchor lookup walks priority list — first anchor type with any member wins (not most-frequent)
+  - _load_domain_anchors swallows all exceptions and returns [] to preserve backward compat
+  - _anchor_label returns None (not empty string) on no match so caller can chain with or
+  - truncation at 40 chars plus ellipsis (U+2026) gives clean single-char suffix, total len 41
+  - community_label_anchors omitted from YAML when None (not present when not provided)
+metrics:
+  duration_seconds: 299
+  completed_at: "2026-04-24T00:48:37Z"
+  tasks_completed: 3
+  tasks_total: 3
+  files_modified: 4
+requirements:
+  - FDA-09
+---
+
+# Phase 04 Plan 01: Domain-Aware Community Labeling Anchors Summary
+
+Config-driven community labeling anchors: `community_label_anchors` in `domain.yaml` drives human-readable drug/ingredient labels for fda-product-labels graphs, with full backward-compatible fallback to existing `_generate_label` logic.
+
+## What Was Built
+
+### Task 1 — fda-product-labels domain.yaml with community_label_anchors (commit a4e1069)
+
+Created `domains/fda-product-labels/domain.yaml` with 16 entity types, 16 relation types, and the new `community_label_anchors` top-level key as the last entry:
+
+```yaml
+community_label_anchors:
+  - DRUG_PRODUCT
+  - ACTIVE_INGREDIENT
+  - INDICATION
+  - MANUFACTURER
+```
+
+All four anchor types are defined entity types in the schema (validated by tests).
+
+### Task 2 — Anchor-based label path in label_communities.py (commit 9fd17d2)
+
+Added two new functions to `core/label_communities.py`:
+
+- `_anchor_label(members, anchors) -> str | None`: Walks the priority list; first matching anchor type becomes the label source. Format rules: 1 match returns name, 2 matches returns `"A / B"`, 3+ returns `"A + N more"`. Names truncated at 40 chars with ellipsis suffix.
+- `_load_domain_anchors(graph_data) -> list[str]`: Reads `metadata.domain` from graph_data, resolves domain via `core.domain_resolver.resolve_domain`, returns `community_label_anchors` list. Returns `[]` on any error (unknown domain, missing key, non-list value).
+
+Updated `label_communities()` dispatch:
+
+```python
+domain_anchors = _load_domain_anchors(graph_data)
+# in the label generation loop:
+if domain_anchors:
+    label = _anchor_label(members, domain_anchors) or _generate_label(members)
+else:
+    label = _generate_label(members)
+```
+
+### Task 3 — domain_wizard.py emits community_label_anchors (commit 05747c4)
+
+Updated `generate_domain_yaml()` to accept `community_label_anchors: list[str] | None = None` and conditionally insert it as the last schema key before `yaml.safe_dump`. Updated `generate_domain_package()` with the same optional parameter, passing it through to `generate_domain_yaml()`. All existing callers remain unaffected (parameter defaults to `None`).
+
+## Test Results
+
+```
+12 test_fda09_* tests — 12 passed, 0 failed
+Full regression — 108 passed, 2 skipped, 0 failed
+```
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None. The anchor labeling path is fully wired: `domain.yaml` -> `_load_domain_anchors()` -> `_anchor_label()` -> label output.
+
+## Threat Flags
+
+No new network endpoints, auth paths, file access patterns, or schema changes at trust boundaries beyond those documented in the plan's threat model. T-04-02 (exception swallowing) and T-04-03 (non-list guard) mitigations are implemented as specified.
+
+## Self-Check: PASSED
+
+| Item | Result |
+|------|--------|
+| domains/fda-product-labels/domain.yaml | FOUND |
+| core/label_communities.py | FOUND |
+| core/domain_wizard.py | FOUND |
+| commit a4e1069 (Task 1) | FOUND |
+| commit 9fd17d2 (Task 2) | FOUND |
+| commit 05747c4 (Task 3) | FOUND |

--- a/.planning/phases/04-domain-aware-community-labeling/04-02-PLAN.md
+++ b/.planning/phases/04-domain-aware-community-labeling/04-02-PLAN.md
@@ -1,0 +1,246 @@
+---
+phase: 04-domain-aware-community-labeling
+plan: "02"
+type: execute
+wave: 2
+depends_on:
+  - "04-01"
+files_modified:
+  - epistract-output/fda-smoke-test/communities.json
+  - epistract-output/fda-smoke-test/graph_data.json
+autonomous: false
+requirements:
+  - FDA-09
+
+must_haves:
+  truths:
+    - "Re-running label_communities.py on the fda-smoke-test output dir produces anchor-based labels"
+    - "Community labels contain drug/ingredient names (e.g. 'Fluconazole', 'Risperidone') not mechanism descriptions"
+    - "No community label is the old verbose slash-joined mechanism pattern"
+    - "At least one community label is a short title-cased name under 60 characters"
+    - "Full test_unit.py suite still passes after re-labeling"
+  artifacts:
+    - path: "epistract-output/fda-smoke-test/communities.json"
+      provides: "Re-labeled community assignments using anchor-based labels"
+      contains: "short drug/ingredient/indication names as label values"
+    - path: "epistract-output/fda-smoke-test/graph_data.json"
+      provides: "Node community fields updated with new anchor-based labels"
+  key_links:
+    - from: "core/label_communities.py:label_communities()"
+      to: "epistract-output/fda-smoke-test/graph_data.json"
+      via: "python -m core.label_communities epistract-output/fda-smoke-test"
+      pattern: "metadata.domain == fda-product-labels -> community_label_anchors loaded"
+---
+
+<objective>
+Re-run community labeling on the existing fda-smoke-test graph output to verify that
+anchor-based labels are produced. Confirm labels are human-readable drug/ingredient
+names rather than verbose mechanism descriptions.
+
+Purpose: End-to-end validation that FDA-09 SC3 is met — community labels for the
+fda-product-labels graph use drug/ingredient names as anchors, not mechanism-of-action
+or dosage-regimen descriptions.
+
+Output:
+- `epistract-output/fda-smoke-test/communities.json` updated with anchor-based labels
+- `epistract-output/fda-smoke-test/graph_data.json` node community fields updated
+- Human checkpoint: user confirms labels are readable
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/phases/04-domain-aware-community-labeling/04-01-SUMMARY.md
+@core/label_communities.py
+@domains/fda-product-labels/domain.yaml
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Re-run label_communities.py on fda-smoke-test graph</name>
+  <files>epistract-output/fda-smoke-test/communities.json, epistract-output/fda-smoke-test/graph_data.json</files>
+  <read_first>
+    - epistract-output/fda-smoke-test/communities.json (first 20 lines — confirm current verbose labels are still present before re-run)
+    - core/label_communities.py (grep for _anchor_label and _load_domain_anchors — confirm Plan 01 was applied)
+  </read_first>
+  <action>
+Before running, verify Plan 01 changes are in place:
+
+```bash
+grep -c "_anchor_label\|_load_domain_anchors" /home/chrisdavidson/programming/epistract/core/label_communities.py
+```
+
+Expected: 4 or more (each function defined + called). If 0, stop and report that Plan 01
+was not applied.
+
+Run the labeler from the repository root:
+
+```bash
+cd /home/chrisdavidson/programming/epistract
+python -m core.label_communities epistract-output/fda-smoke-test
+```
+
+The script prints a JSON array to stdout — each entry has keys: `community` (old name),
+`label` (new name), `members` (count). Inspect the output.
+
+Then sample the updated labels:
+
+```bash
+python3 -c "
+import json
+from pathlib import Path
+communities = json.loads(Path('epistract-output/fda-smoke-test/communities.json').read_text())
+unique_labels = sorted(set(communities.values()))
+print(f'Unique community labels ({len(unique_labels)} total):')
+for label in unique_labels[:20]:
+    print(' ', repr(label))
+"
+```
+
+If labels still look verbose (anchor dispatch not working), run this diagnostic:
+
+```bash
+python3 -c "
+from core.label_communities import _load_domain_anchors
+import json
+from pathlib import Path
+gd = json.loads(Path('epistract-output/fda-smoke-test/graph_data.json').read_text())
+print('domain:', gd.get('metadata', {}).get('domain'))
+print('anchors:', _load_domain_anchors(gd))
+"
+```
+
+Expected diagnostic output:
+```
+domain: fda-product-labels
+anchors: ['DRUG_PRODUCT', 'ACTIVE_INGREDIENT', 'INDICATION', 'MANUFACTURER']
+```
+
+If anchors list is empty, check that `domains/fda-product-labels/domain.yaml` contains
+`community_label_anchors` (Plan 01 Task 1). If domain name is wrong, check
+`graph_data.json` metadata.
+  </action>
+  <verify>
+    <automated>cd /home/chrisdavidson/programming/epistract && python3 -c "
+import json
+from pathlib import Path
+communities = json.loads(Path('epistract-output/fda-smoke-test/communities.json').read_text())
+unique_labels = set(communities.values())
+short_labels = [l for l in unique_labels if len(l) < 60]
+assert len(short_labels) > 0, f'No short labels found. Sample: {list(unique_labels)[:3]}'
+print(f'PASS: {len(short_labels)} short labels found of {len(unique_labels)} unique')
+print('Sample:', list(short_labels)[:5])
+"
+    </automated>
+  </verify>
+  <acceptance_criteria>
+    - `python -m core.label_communities epistract-output/fda-smoke-test` exits with code 0
+    - `python3 -c "import json; from pathlib import Path; c=json.loads(Path('epistract-output/fda-smoke-test/communities.json').read_text()); short=[l for l in set(c.values()) if len(l) < 60]; assert len(short) > 0"` exits 0
+    - At least one unique label in communities.json is a plain drug/ingredient/indication name without the old verbose " / mechanism / mechanism" pattern
+  </acceptance_criteria>
+  <done>
+Re-labeling completes without errors. communities.json and graph_data.json are updated.
+At least some labels are short, anchor-based names. Verbose mechanism-chain labels are
+replaced by drug product or ingredient names for communities that contain DRUG_PRODUCT
+or ACTIVE_INGREDIENT members.
+  </done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Human verification of anchor-based label quality</name>
+  <what-built>
+Re-labeled fda-smoke-test communities.json using the new anchor-based labeling from Plan 01.
+Community labels should now use drug product names, active ingredient names, or indication
+names as anchors — not mechanism-of-action or dosage-regimen descriptions.
+  </what-built>
+  <how-to-verify>
+Run this to see a full sample of the updated labels:
+
+```bash
+cd /home/chrisdavidson/programming/epistract
+python3 -c "
+import json
+from pathlib import Path
+communities = json.loads(Path('epistract-output/fda-smoke-test/communities.json').read_text())
+unique_labels = sorted(set(communities.values()))
+print(f'Total unique labels: {len(unique_labels)}')
+print()
+for label in unique_labels[:30]:
+    print(repr(label))
+"
+```
+
+Confirm:
+1. Labels contain recognizable drug names (e.g. 'Fluconazole', 'Risperidone', 'Sunscreen',
+   'Insomnia') or short descriptive names — NOT long mechanism descriptions
+2. Labels do NOT start with verbose patterns like
+   "Ace Inhibition Of Angiotensin-Converting Enzyme..." or
+   "Uv Filter - Organic Sunscreen Combination / Broad Spectrum..."
+3. Labels with multiple anchors use the format "X / Y" (2 anchors) or "X + N more" (3+)
+4. All labels are under ~60 characters OR end with "more"
+
+If labels still look verbose, share the diagnostic output from Task 1 (the `_load_domain_anchors`
+check) so the issue can be diagnosed.
+  </how-to-verify>
+  <resume-signal>
+Type "approved" if labels look human-readable and anchor-based, or describe what you see
+so the issue can be diagnosed.
+  </resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| epistract-output/fda-smoke-test/ | Local filesystem output directory; read/write by label_communities.py; no network calls, no external data ingestion in this plan |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-04-04 | Tampering | communities.json overwritten in-place | accept | Output directory is local scratch; graph structure (nodes/edges) is not modified — only label string values in communities.json and node.community fields in graph_data.json change |
+| T-04-05 | Denial of Service | label_communities run on large graph (1738 nodes) | accept | Single-process Python, in-memory; 1738 nodes is trivially small; no network calls in this plan |
+</threat_model>
+
+<verification>
+After human approval in Task 2, run full regression:
+
+```bash
+cd /home/chrisdavidson/programming/epistract && python -m pytest tests/test_unit.py -x -q 2>&1 | tail -5
+```
+
+Expected: 0 failures.
+
+Confirm FDA-09 SC3 met:
+```bash
+cd /home/chrisdavidson/programming/epistract && python3 -c "
+import json
+from pathlib import Path
+c = json.loads(Path('epistract-output/fda-smoke-test/communities.json').read_text())
+labels = set(c.values())
+print('Unique label count:', len(labels))
+print('Sample labels (first 10 alphabetically):')
+for l in sorted(labels)[:10]:
+    print(' ', repr(l))
+"
+```
+</verification>
+
+<success_criteria>
+- `python -m core.label_communities epistract-output/fda-smoke-test` completes without error
+- Updated communities.json contains short, human-readable labels anchored to drug/ingredient/indication names
+- Human approves the label quality via checkpoint in Task 2
+- Full test_unit.py suite passes with 0 regressions
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/04-domain-aware-community-labeling/04-02-SUMMARY.md`
+</output>

--- a/core/domain_wizard.py
+++ b/core/domain_wizard.py
@@ -948,7 +948,7 @@ def generate_workbench_template(
     data = {
         "title": f"{pretty_name} Knowledge Graph Explorer",
         "subtitle": f"Explore {pretty_lower} entities and relationships",
-        "persona": persona_override.strip() if persona_override else default_persona.strip(),
+        "persona": persona_override.strip() if (persona_override and persona_override.strip()) else default_persona.strip(),
         "placeholder": "Ask a question about the knowledge graph...",
         "loading_message": "Analyzing",
         "starter_questions": [],

--- a/core/domain_wizard.py
+++ b/core/domain_wizard.py
@@ -1236,6 +1236,11 @@ def main(argv: list[str] | None = None) -> int:
     # When absent, generate_workbench_template falls back to the analyst-shaped
     # default with the domain slug substituted.
     persona = schema.get("persona")
+    # community_label_anchors: optional list of entity types used to anchor
+    # community labels (domain-aware labeling).  Must be read here so that
+    # --schema bypass callers can supply anchors without going through the
+    # interactive wizard.
+    community_label_anchors = schema.get("community_label_anchors") or None
 
     # D-11: bypass the 3-pass LLM discovery — call generate_domain_package directly.
     # Mirror commands/domain.md:140 slug convention (hyphens → underscores for function names).
@@ -1252,6 +1257,7 @@ def main(argv: list[str] | None = None) -> int:
         gap_target_types=gap_target_types,
         confidence_thresholds=confidence_thresholds,
         persona=persona,
+        community_label_anchors=community_label_anchors,
     )
 
     print(f"Domain package created at: {result['domain_dir']}")

--- a/core/domain_wizard.py
+++ b/core/domain_wizard.py
@@ -417,6 +417,7 @@ def generate_domain_yaml(
     system_context: str,
     entity_types: dict,
     relation_types: dict,
+    community_label_anchors: list[str] | None = None,
 ) -> str:
     """Generate domain.yaml content as YAML string.
 
@@ -426,6 +427,9 @@ def generate_domain_yaml(
         system_context: System prompt for LLM extraction context.
         entity_types: Dict of entity type name -> {description}.
         relation_types: Dict of relation type name -> {description}.
+        community_label_anchors: Optional ordered list of entity type names used
+            as label anchors for community detection output. When provided, emitted
+            as the last top-level key in domain.yaml. Omitted when None.
 
     Returns:
         YAML string ready to write to domain.yaml.
@@ -438,6 +442,8 @@ def generate_domain_yaml(
         "entity_types": entity_types,
         "relation_types": relation_types,
     }
+    if community_label_anchors is not None:
+        schema["community_label_anchors"] = community_label_anchors
     return yaml.safe_dump(
         schema,
         default_flow_style=False,
@@ -1061,6 +1067,7 @@ def generate_domain_package(
     gap_target_types: dict | None = None,
     confidence_thresholds: dict | None = None,
     persona: str | None = None,
+    community_label_anchors: list[str] | None = None,
 ) -> dict:
     """Generate and write a complete domain package.
 
@@ -1097,6 +1104,7 @@ def generate_domain_package(
     # Generate all artifacts
     domain_yaml = generate_domain_yaml(
         domain_name, description, system_context, entity_types, relation_types,
+        community_label_anchors=community_label_anchors,
     )
     skill_md = generate_skill_md(
         domain_name, system_context, entity_types, relation_types,

--- a/core/label_communities.py
+++ b/core/label_communities.py
@@ -14,6 +14,67 @@ from collections import Counter
 from pathlib import Path
 
 
+def _anchor_label(members: list[dict], anchors: list[str]) -> str | None:
+    """Generate a community label using domain-configured anchor entity types.
+
+    Walks the priority list (anchors) in order; first anchor type that has
+    at least one member in the community becomes the label source.
+
+    Args:
+        members: List of node dicts with keys "name" and "entity_type".
+        anchors: Ordered priority list of entity type names from domain.yaml
+                 community_label_anchors. First match wins.
+
+    Returns:
+        Label string if any anchor matches, else None (caller falls back to
+        _generate_label for backward compatibility).
+    """
+    MAX_NAME_LEN = 40
+
+    def _truncate(name: str) -> str:
+        cleaned = _clean_name(name)
+        return cleaned[:MAX_NAME_LEN] + "…" if len(cleaned) > MAX_NAME_LEN else cleaned
+
+    for anchor_type in anchors:
+        matched = [m for m in members if m.get("entity_type") == anchor_type]
+        if not matched:
+            continue
+        names = [_truncate(m["name"]) for m in matched]
+        if len(names) == 1:
+            return names[0]
+        if len(names) == 2:
+            return f"{names[0]} / {names[1]}"
+        return f"{names[0]} + {len(names) - 1} more"
+    return None
+
+
+def _load_domain_anchors(graph_data: dict) -> list[str]:
+    """Load community_label_anchors from the domain yaml referenced by graph_data.
+
+    Reads metadata.domain from graph_data, resolves the domain via
+    core.domain_resolver.resolve_domain, and returns community_label_anchors.
+    Returns empty list on any failure to preserve backward compatibility.
+
+    Args:
+        graph_data: Parsed graph_data.json dict.
+
+    Returns:
+        List of anchor entity type names, or [] if not configured or on error.
+    """
+    try:
+        from core.domain_resolver import resolve_domain
+
+        domain_name = graph_data.get("metadata", {}).get("domain")
+        if not domain_name:
+            return []
+        info = resolve_domain(domain_name)
+        schema = info.get("schema") or {}
+        anchors = schema.get("community_label_anchors", [])
+        return anchors if isinstance(anchors, list) else []
+    except Exception:
+        return []
+
+
 def _top_entities(members: list[dict], n: int = 5) -> list[str]:
     """Return the top-N most-connected entity names (by link count) in a community."""
     # Sort by number of connections (approximated by confidence or just alphabetically)
@@ -176,6 +237,10 @@ def label_communities(output_dir: Path) -> dict:
     for node in graph_data.get("nodes", []):
         node_lookup[node["id"]] = node
 
+    # Load domain-configured label anchors (FDA-09). Returns [] when
+    # community_label_anchors is absent from domain.yaml (backward compat).
+    domain_anchors = _load_domain_anchors(graph_data)
+
     # Group members by community
     community_members = {}
     for entity_id, community_name in communities.items():
@@ -191,7 +256,10 @@ def label_communities(output_dir: Path) -> dict:
 
     for old_name in sorted(community_members.keys()):
         members = community_members[old_name]
-        label = _generate_label(members)
+        if domain_anchors:
+            label = _anchor_label(members, domain_anchors) or _generate_label(members)
+        else:
+            label = _generate_label(members)
         label_map[old_name] = label
         results.append({"community": old_name, "label": label, "members": len(members)})
 

--- a/core/label_communities.py
+++ b/core/label_communities.py
@@ -251,7 +251,6 @@ def label_communities(output_dir: Path) -> dict:
 
     # Generate labels
     label_map = {}  # old name -> new name
-    labeled_communities = {}
     results = []
 
     for old_name in sorted(community_members.keys()):

--- a/domains/fda-product-labels/domain.yaml
+++ b/domains/fda-product-labels/domain.yaml
@@ -1,0 +1,105 @@
+name: fda-product-labels
+version: 1.0.0
+description: JSON representations of FDA drug product labels (Structured Product Labeling),
+  covering both prescription and OTC drugs with sections for indications, warnings,
+  adverse reactions, pharmacology, dosing, and regulatory identifiers.
+system_context: You are analyzing FDA Structured Product Labeling (SPL) documents
+  — the authoritative regulatory labels submitted by manufacturers for prescription
+  and over-the-counter drug products. Each document is a JSON file containing clinical
+  sections (indications, contraindications, warnings, adverse reactions, pharmacology)
+  alongside structured openfda metadata (brand/generic names, NDC codes, pharmacologic
+  class, manufacturer). Extract precise, clinically meaningful entities and relationships
+  that would support pharmacovigilance, formulary analysis, drug interaction screening,
+  and regulatory intelligence.
+entity_types:
+  DRUG_PRODUCT:
+    description: A drug product identified by brand/generic name, product type (Rx/OTC),
+      dosage form, and route of administration
+  ACTIVE_INGREDIENT:
+    description: An active pharmaceutical ingredient (API) with substance name and
+      UNII code
+  INACTIVE_INGREDIENT:
+    description: An excipient or inactive ingredient in the formulation
+  MANUFACTURER:
+    description: The manufacturer, labeler, or marketing company responsible for the
+      drug product
+  INDICATION:
+    description: An FDA-approved therapeutic use or clinical condition the drug is
+      indicated to treat
+  CONTRAINDICATION:
+    description: A patient condition, prior history, or co-medication that prohibits
+      use of the drug
+  ADVERSE_REACTION:
+    description: An adverse event or side effect observed in clinical trials or post-marketing
+      surveillance
+  WARNING:
+    description: A boxed warning, warnings-and-precautions entry, or safety signal
+      requiring clinician action
+  DRUG_INTERACTION:
+    description: A clinically significant interaction between this drug and another
+      drug, substance, or food that affects safety or efficacy
+  DOSAGE_REGIMEN:
+    description: A specific dosing instruction including dose amount, frequency, route,
+      and target patient population
+  PATIENT_POPULATION:
+    description: A patient subgroup with special dosing or safety considerations (pediatric,
+      geriatric, renally impaired, pregnant, nursing mothers)
+  MECHANISM_OF_ACTION:
+    description: The pharmacological mechanism by which the active ingredient produces
+      its therapeutic effect
+  PHARMACOKINETIC_PROPERTY:
+    description: A PK parameter including absorption, distribution, metabolism, excretion,
+      half-life, Cmax, bioavailability, or protein binding
+  CLINICAL_STUDY:
+    description: A clinical trial or study referenced in the label to support safety
+      or efficacy claims
+  PHARMACOLOGIC_CLASS:
+    description: An FDA-recognized drug class designation (EPC, MoA, Chemical Structure,
+      or PE classification)
+  REGULATORY_IDENTIFIER:
+    description: A regulatory code such as NDA/ANDA application number, NDC code,
+      RxCUI, UNII, or SPL set ID
+relation_types:
+  HAS_ACTIVE_INGREDIENT:
+    description: Links a DRUG_PRODUCT to its ACTIVE_INGREDIENT(s)
+  HAS_INACTIVE_INGREDIENT:
+    description: Links a DRUG_PRODUCT to its INACTIVE_INGREDIENT(s)
+  MANUFACTURED_BY:
+    description: Links a DRUG_PRODUCT to its MANUFACTURER
+  INDICATED_FOR:
+    description: Links a DRUG_PRODUCT to an INDICATION (FDA-approved use)
+  CONTRAINDICATED_IN:
+    description: Links a DRUG_PRODUCT to a CONTRAINDICATION (prohibited patient condition)
+  CAUSES_ADVERSE_REACTION:
+    description: Links a DRUG_PRODUCT to an ADVERSE_REACTION observed in clinical
+      or post-marketing data
+  HAS_WARNING:
+    description: Links a DRUG_PRODUCT to a WARNING (boxed or standard precaution)
+  INTERACTS_WITH:
+    description: Links a DRUG_PRODUCT to another DRUG_PRODUCT or substance involved
+      in a clinically significant DRUG_INTERACTION
+  DOSED_VIA:
+    description: Links a DRUG_PRODUCT to a DOSAGE_REGIMEN specifying how and when
+      to administer it
+  STUDIED_IN_POPULATION:
+    description: Links a DRUG_PRODUCT to a PATIENT_POPULATION with special safety
+      or dosing notes
+  HAS_MECHANISM:
+    description: Links a DRUG_PRODUCT to its MECHANISM_OF_ACTION
+  HAS_PK_PROPERTY:
+    description: Links a DRUG_PRODUCT to a PHARMACOKINETIC_PROPERTY
+  EVALUATED_IN:
+    description: Links a DRUG_PRODUCT to a CLINICAL_STUDY that supported label claims
+  BELONGS_TO_CLASS:
+    description: Links a DRUG_PRODUCT to its PHARMACOLOGIC_CLASS
+  IDENTIFIED_BY:
+    description: Links a DRUG_PRODUCT to a REGULATORY_IDENTIFIER (NDC, NDA/ANDA, RxCUI,
+      etc.)
+  CONTRAINDICATED_WITH:
+    description: Links a DRUG_PRODUCT to another DRUG_PRODUCT whose co-administration
+      is explicitly prohibited
+community_label_anchors:
+  - DRUG_PRODUCT
+  - ACTIVE_INGREDIENT
+  - INDICATION
+  - MANUFACTURER

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2620,3 +2620,114 @@ def test_fda09_anchor_types_exist_in_entity_types():
     entity_type_names = set(schema.get("entity_types", {}).keys())
     for anchor in schema["community_label_anchors"]:
         assert anchor in entity_type_names, f"Anchor {anchor!r} not found in entity_types"
+
+
+# ---------------------------------------------------------------------------
+# FDA-09: _anchor_label() unit tests — Task 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fda09_anchor_label_single_match():
+    from core.label_communities import _anchor_label
+
+    members = [{"name": "Fluconazole", "entity_type": "DRUG_PRODUCT"}]
+    anchors = ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION"]
+    assert _anchor_label(members, anchors) == "Fluconazole"
+
+
+@pytest.mark.unit
+def test_fda09_anchor_label_two_matches_slash():
+    from core.label_communities import _anchor_label
+
+    members = [
+        {"name": "Aspirin", "entity_type": "DRUG_PRODUCT"},
+        {"name": "Ibuprofen", "entity_type": "DRUG_PRODUCT"},
+    ]
+    result = _anchor_label(members, ["DRUG_PRODUCT"])
+    assert result == "Aspirin / Ibuprofen"
+
+
+@pytest.mark.unit
+def test_fda09_anchor_label_three_plus_more():
+    from core.label_communities import _anchor_label
+
+    members = [
+        {"name": "Alpha", "entity_type": "DRUG_PRODUCT"},
+        {"name": "Beta", "entity_type": "DRUG_PRODUCT"},
+        {"name": "Gamma", "entity_type": "DRUG_PRODUCT"},
+    ]
+    result = _anchor_label(members, ["DRUG_PRODUCT"])
+    assert result == "Alpha + 2 more"
+
+
+@pytest.mark.unit
+def test_fda09_anchor_label_truncation():
+    from core.label_communities import _anchor_label
+
+    long_name = "A" * 50  # 50 chars; _clean_name title-cases but 'A'*50 stays 50 'A's
+    members = [{"name": long_name, "entity_type": "DRUG_PRODUCT"}]
+    result = _anchor_label(members, ["DRUG_PRODUCT"])
+    assert result is not None
+    assert result.endswith("…"), f"Expected ellipsis suffix, got: {result!r}"
+    assert len(result) == 41  # 40 chars + 1 ellipsis char
+
+
+@pytest.mark.unit
+def test_fda09_anchor_label_priority_fallback():
+    """DRUG_PRODUCT absent; falls back to ACTIVE_INGREDIENT."""
+    from core.label_communities import _anchor_label
+
+    members = [{"name": "Fluoxetine", "entity_type": "ACTIVE_INGREDIENT"}]
+    result = _anchor_label(members, ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION"])
+    assert result == "Fluoxetine"
+
+
+@pytest.mark.unit
+def test_fda09_anchor_label_no_match_returns_none():
+    from core.label_communities import _anchor_label
+
+    members = [
+        {"name": "Some Mechanism", "entity_type": "MECHANISM_OF_ACTION"},
+        {"name": "500mg Tablet Daily", "entity_type": "DOSAGE_REGIMEN"},
+    ]
+    result = _anchor_label(members, ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION"])
+    assert result is None
+
+
+@pytest.mark.unit
+def test_fda09_backward_compat_no_anchors(tmp_path, monkeypatch):
+    """Domains without community_label_anchors must use _generate_label (no crash)."""
+    import json
+    import core.label_communities as lc
+
+    monkeypatch.setattr(lc, "_load_domain_anchors", lambda gd: [])
+
+    communities = {"gene:tp53": "community_0"}
+    graph_data = {
+        "metadata": {"domain": "drug-discovery"},
+        "nodes": [{"id": "gene:tp53", "name": "TP53", "entity_type": "GENE"}],
+    }
+    (tmp_path / "communities.json").write_text(json.dumps(communities))
+    (tmp_path / "graph_data.json").write_text(json.dumps(graph_data))
+
+    result = lc.label_communities(tmp_path)
+    assert isinstance(result, dict)
+    assert len(result) == 1
+
+
+@pytest.mark.unit
+def test_fda09_backward_compat_missing_domain_metadata(tmp_path):
+    """graph_data.json with no metadata.domain -> _generate_label fallback (no crash)."""
+    import json
+    import core.label_communities as lc
+
+    communities = {"gene:brca1": "community_0"}
+    graph_data = {
+        "nodes": [{"id": "gene:brca1", "name": "BRCA1", "entity_type": "GENE"}],
+    }
+    (tmp_path / "communities.json").write_text(json.dumps(communities))
+    (tmp_path / "graph_data.json").write_text(json.dumps(graph_data))
+
+    result = lc.label_communities(tmp_path)
+    assert isinstance(result, dict)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2589,3 +2589,34 @@ def test_ctdm06_enrich_non_blocking():
         # Must return None, not raise
         assert enrich._fetch_ct_gov("NCT04303780") is None
         assert enrich._fetch_pubchem("remdesivir") is None
+
+
+# ---------------------------------------------------------------------------
+# FDA-09: community_label_anchors — Task 1 tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fda09_domain_yaml_has_anchors():
+    """FDA-09 SC1: fda-product-labels domain.yaml contains community_label_anchors list."""
+    import yaml
+    from core.domain_resolver import DOMAINS_DIR
+
+    yaml_path = DOMAINS_DIR / "fda-product-labels" / "domain.yaml"
+    schema = yaml.safe_load(yaml_path.read_text())
+    assert "community_label_anchors" in schema, "community_label_anchors missing from domain.yaml"
+    anchors = schema["community_label_anchors"]
+    assert anchors == ["DRUG_PRODUCT", "ACTIVE_INGREDIENT", "INDICATION", "MANUFACTURER"]
+
+
+@pytest.mark.unit
+def test_fda09_anchor_types_exist_in_entity_types():
+    """FDA-09: all anchor types must be defined entity_types in the schema."""
+    import yaml
+    from core.domain_resolver import DOMAINS_DIR
+
+    yaml_path = DOMAINS_DIR / "fda-product-labels" / "domain.yaml"
+    schema = yaml.safe_load(yaml_path.read_text())
+    entity_type_names = set(schema.get("entity_types", {}).keys())
+    for anchor in schema["community_label_anchors"]:
+        assert anchor in entity_type_names, f"Anchor {anchor!r} not found in entity_types"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -2731,3 +2731,46 @@ def test_fda09_backward_compat_missing_domain_metadata(tmp_path):
 
     result = lc.label_communities(tmp_path)
     assert isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# FDA-09: domain_wizard community_label_anchors emission — Task 3
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fda09_wizard_generate_domain_yaml_with_anchors():
+    """generate_domain_yaml with anchors emits community_label_anchors in YAML."""
+    import yaml
+    from core.domain_wizard import generate_domain_yaml
+
+    result = generate_domain_yaml(
+        domain_name="Test Domain",
+        description="A test domain",
+        system_context="Extract test entities",
+        entity_types={"FOO": {"description": "Foo entity"}},
+        relation_types={"HAS_FOO": {"description": "Has foo"}},
+        community_label_anchors=["FOO"],
+    )
+    parsed = yaml.safe_load(result)
+    assert "community_label_anchors" in parsed, "anchors missing from generated YAML"
+    assert parsed["community_label_anchors"] == ["FOO"]
+
+
+@pytest.mark.unit
+def test_fda09_wizard_generate_domain_yaml_without_anchors():
+    """generate_domain_yaml without anchors does NOT emit community_label_anchors (backward compat)."""
+    import yaml
+    from core.domain_wizard import generate_domain_yaml
+
+    result = generate_domain_yaml(
+        domain_name="Test Domain",
+        description="A test domain",
+        system_context="Extract test entities",
+        entity_types={"FOO": {"description": "Foo entity"}},
+        relation_types={"HAS_FOO": {"description": "Has foo"}},
+    )
+    parsed = yaml.safe_load(result)
+    assert "community_label_anchors" not in parsed, (
+        "community_label_anchors should be absent when not provided"
+    )


### PR DESCRIPTION
## Summary

Adds configurable `community_label_anchors` to the domain schema, allowing each domain to declare which entity types should drive community labels in the knowledge graph. Replaces verbose mechanism-chain labels with human-readable drug/ingredient/indication names for the `fda-product-labels` domain.

**Before:** `'Ace Inhibition Of Angiotensin-Converting Enzyme / Ampa/Kainate Glutamate Receptor Antagonism / Gaba-A Receptor Potentiation'`
**After:** `'Lisinopril And Hydrochlorothiazide… / Topiramate Tablets'`

## Changes

- `domains/fda-product-labels/domain.yaml` — adds `community_label_anchors: [DRUG_PRODUCT, ACTIVE_INGREDIENT, INDICATION, MANUFACTURER]`
- `core/label_communities.py` — adds `_anchor_label()` priority-list dispatch and `_load_domain_anchors()` with backward-compatible fallback; removes dead variable
- `core/domain_wizard.py` — `generate_domain_yaml()` / `generate_domain_package()` accept optional `community_label_anchors`; `--schema` bypass now threads anchors through; whitespace persona guard fixed
- `tests/test_unit.py` — 12 new `test_fda09_*` TDD tests covering anchor path, fallback path, truncation, multi-anchor format, and backward compatibility

## Backward compatibility

Domains without `community_label_anchors` in their `domain.yaml` (drug-discovery, contracts, clinicaltrials) are unaffected — `_load_domain_anchors()` returns `[]` and `_generate_label()` is used as before.

## Test plan

- [ ] `python3 -m pytest tests/test_unit.py -k "test_fda09" -v` — 12 tests pass
- [ ] `python3 -m pytest tests/test_unit.py -x -q` — full suite: 108 passed, 2 skipped, 0 failed
- [ ] `python3 -m core.label_communities <fda-output-dir>` — produces drug/ingredient names, 0 mechanism-chain labels